### PR TITLE
Implement OpenAI JSON caller

### DIFF
--- a/agent1/openai_client.py
+++ b/agent1/openai_client.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import orjson
+import time
+
+# openai is imported lazily in tests via a stub if not installed
+import openai
+
+PROMPT_PATH = Path(__file__).resolve().parents[1] / "prompts" / "agent1_prompt.txt"
+
+
+class OpenAIJSONCaller:
+    """Helper for calling OpenAI's chat completion API in JSON mode."""
+
+    def __init__(self, model: str = "gpt-4-0125-preview") -> None:
+        self.model = model
+        self.prompt = PROMPT_PATH.read_text()
+
+    def call(self, user_content: str, *, max_retries: int = 2) -> Dict[str, Any]:
+        """Send ``user_content`` to the model and parse the JSON reply."""
+        messages = [
+            {"role": "system", "content": self.prompt},
+            {"role": "user", "content": user_content},
+        ]
+        delay = 1.0
+        for attempt in range(max_retries + 1):
+            response = openai.ChatCompletion.create(
+                model=self.model,
+                messages=messages,
+                response_format={"type": "json_object"},
+            )
+            content = response["choices"][0]["message"]["content"]
+            try:
+                return orjson.loads(content)
+            except orjson.JSONDecodeError:
+                if attempt >= max_retries:
+                    raise
+                time.sleep(delay)
+                delay *= 2
+        # Should never reach here
+        raise RuntimeError("Failed to obtain JSON from OpenAI")

--- a/prompts/agent1_prompt.txt
+++ b/prompts/agent1_prompt.txt
@@ -1,0 +1,2 @@
+You are Agent 1.
+Provide metadata in JSON format.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic
 orjson
 reportlab
 
+openai

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,75 @@
+import sys
+import types
+
+import orjson
+import pytest
+
+# Create a fake openai module
+fake_openai = types.ModuleType("openai")
+
+
+class FakeChatCompletion:
+    def __init__(self):
+        self.calls = []
+        self.responses = []
+
+    def create(self, *args, **kwargs):
+        self.calls.append({"args": args, "kwargs": kwargs})
+        return self.responses.pop(0)
+
+
+fake_chat = FakeChatCompletion()
+fake_openai.ChatCompletion = fake_chat
+sys.modules["openai"] = fake_openai
+
+from agent1.openai_client import OpenAIJSONCaller  # noqa: E402
+
+
+def setup_prompt(tmp_path):
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    path = prompt_dir / "agent1_prompt.txt"
+    path.write_text("Prompt")
+    return path
+
+
+def test_success(monkeypatch, tmp_path):
+    path = setup_prompt(tmp_path)
+    monkeypatch.setattr("agent1.openai_client.PROMPT_PATH", path)
+    fake_chat.calls.clear()
+    fake_chat.responses = [{"choices": [{"message": {"content": '{"ok": 1}'}}]}]
+    client = OpenAIJSONCaller(model="test")
+    result = client.call("hello")
+    assert result == {"ok": 1}
+    assert len(fake_chat.calls) == 1
+
+
+def test_retry(monkeypatch, tmp_path):
+    path = setup_prompt(tmp_path)
+    monkeypatch.setattr("agent1.openai_client.PROMPT_PATH", path)
+    fake_chat.calls.clear()
+    fake_chat.responses = [
+        {"choices": [{"message": {"content": "not json"}}]},
+        {"choices": [{"message": {"content": '{"ok": 2}'}}]},
+    ]
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    client = OpenAIJSONCaller(model="test")
+    result = client.call("hello")
+    assert result == {"ok": 2}
+    assert len(fake_chat.calls) == 2
+
+
+def test_fail(monkeypatch, tmp_path):
+    path = setup_prompt(tmp_path)
+    monkeypatch.setattr("agent1.openai_client.PROMPT_PATH", path)
+    fake_chat.calls.clear()
+    fake_chat.responses = [
+        {"choices": [{"message": {"content": "bad"}}]},
+        {"choices": [{"message": {"content": "still bad"}}]},
+        {"choices": [{"message": {"content": "nope"}}]},
+    ]
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    client = OpenAIJSONCaller(model="test")
+    with pytest.raises(orjson.JSONDecodeError):
+        client.call("hello")
+    assert len(fake_chat.calls) == 3


### PR DESCRIPTION
## Summary
- add `OpenAIJSONCaller` helper class for using OpenAI API with JSON mode and retries
- include default agent1 prompt template
- add dependency on `openai`
- test JSON parsing success, retry logic and failure cases

## Testing
- `black tests/test_openai_client.py agent1/openai_client.py`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686125a903488324bbe5d2c8c41bf8e3