### PR TITLE
Add metadata extraction pipeline

### DIFF
--- a/agent1/metadata_extractor.py
+++ b/agent1/metadata_extractor.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+from hashlib import md5
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Union
+
+import orjson
+from pydantic import ValidationError
+
+from agent1.openai_client import OpenAIJSONCaller
+from schemas.metadata import PaperMetadata
+
+META_DIR = Path(__file__).resolve().parents[1] / "data" / "meta"
+
+
+class MetadataExtractor:
+    """Extract metadata from text using OpenAI and validate against schema."""
+
+    def __init__(self, client: Optional[OpenAIJSONCaller] = None) -> None:
+        self.client = client or OpenAIJSONCaller()
+        META_DIR.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _join_pages(pages: Iterable[Dict[str, Any]]) -> str:
+        return "\n".join(page.get("text", "") for page in pages)
+
+    def _load_text(self, text_or_path: Union[str, Path]) -> tuple[str, Optional[Path]]:
+        path = Path(text_or_path)
+        if path.exists():
+            data = orjson.loads(path.read_bytes())
+            text = self._join_pages(data.get("pages", []))
+            return text, path
+        return str(text_or_path), None
+
+    @staticmethod
+    def _safe_name(doi: Optional[str], fallback: str) -> str:
+        if doi:
+            return doi.replace("/", "_").replace(":", "_")
+        digest = md5(fallback.encode(), usedforsecurity=False).hexdigest()[:8]
+        return f"no-doi-{digest}"
+
+    def _save(
+        self, metadata: PaperMetadata, text_path: Optional[Path], raw_text: str
+    ) -> Path:
+        name = self._safe_name(
+            metadata.doi, text_path.stem if text_path else raw_text[:10]
+        )
+        out_path = META_DIR / f"{name}.json"
+        out_path.write_bytes(orjson.dumps(metadata.model_dump()))
+        return out_path
+
+    def extract(self, text_or_path: Union[str, Path]) -> Optional[PaperMetadata]:
+        text, src_path = self._load_text(text_or_path)
+        for attempt in range(2):
+            try:
+                result = self.client.call(text)
+                metadata = PaperMetadata.model_validate(result)
+            except (ValidationError, Exception) as exc:
+                logging.error("Validation failed on attempt %s: %s", attempt + 1, exc)
+                if attempt == 1:
+                    return None
+            else:
+                self._save(metadata, src_path, text)
+                return metadata
+        return None
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Extract metadata using OpenAI")
+    parser.add_argument("text", help="Raw text or path to text JSON")
+    args = parser.parse_args()
+
+    extractor = MetadataExtractor()
+    result = extractor.extract(args.text)
+    if result is None:
+        print("Extraction failed")
+    else:
+        print(orjson.dumps(result.model_dump()).decode())

--- a/tests/test_metadata_extractor.py
+++ b/tests/test_metadata_extractor.py
@@ -1,0 +1,84 @@
+import sys
+import types
+from pathlib import Path
+
+import orjson
+
+
+class FakeClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = 0
+
+    def call(self, text, *, max_retries=2):
+        self.calls += 1
+        return self.responses.pop(0)
+
+
+def setup_module(module):
+    sys.modules["openai"] = types.ModuleType("openai")
+
+
+def teardown_module(module):
+    for mod in ("agent1.metadata_extractor", "agent1.openai_client", "openai"):
+        sys.modules.pop(mod, None)
+
+
+def create_text_file(tmp_path: Path, name: str) -> Path:
+    path = tmp_path / f"{name}.json"
+    data = {"pages": [{"page": 1, "text": "dummy text"}]}
+    path.write_bytes(orjson.dumps(data))
+    return path
+
+
+def valid_data() -> dict:
+    return {
+        "title": "T",
+        "authors": "A",
+        "doi": "10.1/abc",
+        "pub_date": None,
+        "data_sources": None,
+        "omics_modalities": None,
+        "targets": None,
+        "p_threshold": None,
+        "ld_r2": None,
+    }
+
+
+def test_extract_success(tmp_path, monkeypatch):
+    from agent1.metadata_extractor import MetadataExtractor
+
+    text_path = create_text_file(tmp_path, "test")
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+    client = FakeClient([valid_data()])
+    extractor = MetadataExtractor(client=client)
+    result = extractor.extract(text_path)
+    assert result is not None
+    out_file = tmp_path / "meta" / "10.1_abc.json"
+    assert out_file.exists()
+    assert client.calls == 1
+
+
+def test_extract_retry(tmp_path, monkeypatch):
+    from agent1.metadata_extractor import MetadataExtractor
+
+    text_path = create_text_file(tmp_path, "test")
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+    client = FakeClient([{"title": 1}, valid_data()])
+    extractor = MetadataExtractor(client=client)
+    result = extractor.extract(text_path)
+    assert result is not None
+    assert client.calls == 2
+
+
+def test_extract_fail(tmp_path, monkeypatch):
+    from agent1.metadata_extractor import MetadataExtractor
+
+    text_path = create_text_file(tmp_path, "test")
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+    client = FakeClient([{"title": 1}, {"title": 2}])
+    extractor = MetadataExtractor(client=client)
+    result = extractor.extract(text_path)
+    assert result is None
+    assert client.calls == 2
+    assert not list((tmp_path / "meta").glob("*.json"))


### PR DESCRIPTION
## Summary
- implement `MetadataExtractor` to call OpenAI and validate against `PaperMetadata`
- save successful metadata extraction results to `data/meta/<doi>.json`
- add unit tests covering success, retry, and failure cases for the extractor

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68614225f8b88324b934c91535f385a8