### PR TITLE
Add Agent 1 CLI runner and tests

### DIFF
--- a/agent1/run.py
+++ b/agent1/run.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from extract import pdf_to_text
+from agent1.metadata_extractor import MetadataExtractor, META_DIR
+
+
+def process_pdf(pdf_path: Path) -> bool:
+    """Convert *pdf_path* to text and extract metadata."""
+    pdf_to_text.pdf_to_text(pdf_path)
+    text_path = pdf_to_text.DATA_DIR / f"{pdf_path.stem}.json"
+    extractor = MetadataExtractor()
+    metadata = extractor.extract(text_path)
+    if metadata is None:
+        print(f"Failed to extract metadata from {pdf_path}")
+        return False
+    name = MetadataExtractor._safe_name(metadata.doi, pdf_path.stem)
+    out_path = META_DIR / f"{name}.json"
+    print(f"Metadata saved to {out_path}")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run Agent 1 on a PDF")
+    parser.add_argument("--pdf", required=True, help="Path to PDF file")
+    args = parser.parse_args(argv)
+    success = process_pdf(Path(args.pdf))
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent1/test_agent1_metadata.py
+++ b/tests/agent1/test_agent1_metadata.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import orjson
+import pytest
+
+from schemas.metadata import PaperMetadata
+
+
+class FakeClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = 0
+
+    def call(self, _text, *, max_retries=2):
+        self.calls += 1
+        return self.responses.pop(0)
+
+
+def create_text_file(tmp_path: Path) -> Path:
+    data = {"pages": [{"page": 1, "text": "content"}]}
+    path = tmp_path / "text.json"
+    path.write_bytes(orjson.dumps(data))
+    return path
+
+
+def create_pdf(path: Path) -> None:
+    from reportlab.lib.pagesizes import letter
+    from reportlab.pdfgen import canvas
+
+    c = canvas.Canvas(str(path), pagesize=letter)
+    c.drawString(100, 750, "Hello")
+    c.showPage()
+    c.save()
+
+
+def test_retry_logic(monkeypatch, tmp_path):
+    from agent1.metadata_extractor import MetadataExtractor
+
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+    text_path = create_text_file(tmp_path)
+    client = FakeClient([{"title": 1}, {"title": "T"}])
+    extractor = MetadataExtractor(client=client)
+    result = extractor.extract(text_path)
+    assert result is not None
+    assert client.calls == 2
+
+
+def test_paper_metadata_validation():
+    data = {
+        "title": "T",
+        "authors": "A",
+        "doi": "10.1/abc",
+        "pub_date": "2024-01-01",
+        "data_sources": ["db"],
+        "omics_modalities": ["gen"],
+        "targets": ["t"],
+        "p_threshold": "1e-5",
+        "ld_r2": "0.1",
+    }
+    meta = PaperMetadata(**data)
+    assert meta.title == "T"
+    with pytest.raises(Exception):
+        PaperMetadata(title=123)  # type: ignore
+
+
+def test_cli_end_to_end(monkeypatch, tmp_path):
+
+    result = {"title": "T", "doi": "10.1/x"}
+    fake_client = FakeClient([result])
+    monkeypatch.setattr(
+        "agent1.metadata_extractor.OpenAIJSONCaller", lambda: fake_client
+    )
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+    monkeypatch.setattr("extract.pdf_to_text.DATA_DIR", tmp_path / "text")
+
+    import agent1.run as run
+
+    pdf = tmp_path / "paper.pdf"
+    create_pdf(pdf)
+
+    code = run.main(["--pdf", str(pdf)])
+    assert code == 0
+    out_file = tmp_path / "meta" / "10.1_x.json"
+    assert out_file.exists()
+    loaded = orjson.loads(out_file.read_bytes())
+    PaperMetadata.model_validate(loaded)
+    assert fake_client.calls == 1


### PR DESCRIPTION
## Summary
- implement `agent1.run` CLI for processing a PDF with Agent 1
- provide new unit tests for Agent 1 including CLI integration

## Testing
- `black .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686144a65a748324accc7fa684fa7b32