### PR TITLE
Add metadata aggregator

### DIFF
--- a/aggregate.py
+++ b/aggregate.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+import orjson
+from pydantic import ValidationError
+
+from schemas.metadata import PaperMetadata
+
+META_DIR = Path(__file__).resolve().parent / "data" / "meta"
+OUT_PATH = Path(__file__).resolve().parent / "data" / "master.json"
+
+
+def aggregate() -> list[PaperMetadata]:
+    entries: list[PaperMetadata] = []
+    META_DIR.mkdir(parents=True, exist_ok=True)
+    for path in sorted(META_DIR.glob("*.json")):
+        try:
+            data = orjson.loads(path.read_bytes())
+            entry = PaperMetadata.model_validate(data)
+        except (orjson.JSONDecodeError, ValidationError):
+            continue
+        entries.append(entry)
+    OUT_PATH.write_bytes(orjson.dumps([e.model_dump() for e in entries]))
+    return entries
+
+
+if __name__ == "__main__":
+    result = aggregate()
+    print(orjson.dumps([e.model_dump() for e in result]).decode())

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import orjson
+
+from aggregate import aggregate
+from schemas.metadata import PaperMetadata
+
+
+def write_json(path: Path, data) -> None:  # data may be dict or other
+    if isinstance(data, str):
+        path.write_text(data)
+    else:
+        path.write_bytes(orjson.dumps(data))
+
+
+def test_aggregate(monkeypatch, tmp_path: Path) -> None:
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    monkeypatch.setattr("aggregate.META_DIR", meta_dir)
+    out_path = tmp_path / "master.json"
+    monkeypatch.setattr("aggregate.OUT_PATH", out_path)
+
+    valid_data = {"title": "Example Title"}
+    write_json(meta_dir / "valid.json", valid_data)
+    write_json(meta_dir / "bad.json", "not json")
+    write_json(meta_dir / "invalid.json", [1, 2, 3])
+
+    results = aggregate()
+
+    assert out_path.exists()
+    out = orjson.loads(out_path.read_bytes())
+    assert out == [PaperMetadata.model_validate(valid_data).model_dump()]
+    assert len(results) == 1


### PR DESCRIPTION
## Summary
- add `aggregate.py` to collate metadata JSONs
- write unit tests for the aggregator

## Testing
- `black .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68614506b370832496d0f7a47b0ea03b