### PR TITLE
Add metadata aggregation with error logging

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+import logging
+import orjson
+from pydantic import ValidationError
+
+from schemas.metadata import PaperMetadata
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+META_DIR = DATA_DIR / "meta"
+MASTER_PATH = DATA_DIR / "master.json"
+ERROR_LOG = DATA_DIR / "aggregation_errors.log"
+
+
+def _log_error(path: Path, exc: Exception) -> None:
+    timestamp = datetime.utcnow().isoformat()
+    message = f'[{timestamp}] Invalid JSON in file {path}: "{exc}"\n'
+    ERROR_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with ERROR_LOG.open("a") as f:
+        f.write(message)
+    logging.error("Invalid JSON in file %s: %s", path, exc)
+
+
+def aggregate_metadata() -> List[PaperMetadata]:
+    META_DIR.mkdir(parents=True, exist_ok=True)
+    records: List[PaperMetadata] = []
+    for json_file in sorted(META_DIR.glob("*.json")):
+        try:
+            data = orjson.loads(json_file.read_bytes())
+            metadata = PaperMetadata.model_validate(data)
+        except (orjson.JSONDecodeError, ValidationError) as exc:
+            _log_error(json_file, exc)
+            continue
+        records.append(metadata)
+
+    MASTER_PATH.write_bytes(
+        orjson.dumps([r.model_dump() for r in records], option=orjson.OPT_INDENT_2)
+    )
+    return records
+
+
+if __name__ == "__main__":
+    aggregate_metadata()

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,42 @@
+import orjson
+from aggregator import aggregate_metadata
+
+
+def valid_data():
+    return {
+        "title": "T",
+        "authors": "A",
+        "doi": "10.1/abc",
+        "pub_date": None,
+        "data_sources": None,
+        "omics_modalities": None,
+        "targets": None,
+        "p_threshold": None,
+        "ld_r2": None,
+    }
+
+
+def test_aggregate_with_invalid_json(tmp_path, monkeypatch):
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    master = tmp_path / "master.json"
+    error_log = tmp_path / "aggregation_errors.log"
+
+    monkeypatch.setattr("aggregator.META_DIR", meta_dir)
+    monkeypatch.setattr("aggregator.MASTER_PATH", master)
+    monkeypatch.setattr("aggregator.ERROR_LOG", error_log)
+
+    # valid file
+    (meta_dir / "valid.json").write_bytes(orjson.dumps(valid_data()))
+    # invalid file (wrong type)
+    (meta_dir / "invalid.json").write_bytes(orjson.dumps({"title": 1}))
+
+    results = aggregate_metadata()
+
+    assert len(results) == 1
+    assert master.exists()
+    data = orjson.loads(master.read_bytes())
+    assert len(data) == 1
+    assert error_log.exists()
+    log_content = error_log.read_text()
+    assert "invalid.json" in log_content


### PR DESCRIPTION
## Summary
- implement `aggregator.py` to combine metadata JSON files
- log validation failures to `data/aggregation_errors.log`
- add unit test for aggregator behaviour

## Testing
- `ruff check .`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861451fa0b483248b8742cfba88a9c9