### PR TITLE
Implement master.json backup on aggregation

### DIFF
--- a/aggregate.py
+++ b/aggregate.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+import orjson
+from schemas.metadata import PaperMetadata
+
+BASE_DIR = Path(__file__).resolve().parent
+META_DIR = BASE_DIR / "data" / "meta"
+MASTER_PATH = BASE_DIR / "data" / "master.json"
+HISTORY_DIR = BASE_DIR / "data" / "master_history"
+
+
+def load_metadata() -> List[dict]:
+    META_DIR.mkdir(parents=True, exist_ok=True)
+    records: List[dict] = []
+    for path in sorted(META_DIR.glob("*.json")):
+        try:
+            data = orjson.loads(path.read_bytes())
+            record = PaperMetadata.model_validate(data)
+            records.append(record.model_dump())
+        except Exception:
+            continue
+    return records
+
+
+def backup_master() -> None:
+    if MASTER_PATH.exists():
+        HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+        backup = HISTORY_DIR / f"master_{timestamp}.json"
+        backup.write_bytes(MASTER_PATH.read_bytes())
+
+
+def aggregate() -> Path:
+    records = load_metadata()
+    backup_master()
+    MASTER_PATH.write_bytes(orjson.dumps(records))
+    return MASTER_PATH
+
+
+if __name__ == "__main__":
+    aggregate()

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from pathlib import Path
+
+import orjson
+import pytest
+
+import aggregate
+from schemas.metadata import PaperMetadata
+
+
+def create_meta_file(dir_path: Path, name: str) -> None:
+    data = PaperMetadata(title=name).model_dump()
+    (dir_path / f"{name}.json").write_bytes(orjson.dumps(data))
+
+
+def test_aggregate_creates_master(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    create_meta_file(meta_dir, "a")
+    create_meta_file(meta_dir, "b")
+    monkeypatch.setattr(aggregate, "META_DIR", meta_dir)
+    master_path = tmp_path / "master.json"
+    monkeypatch.setattr(aggregate, "MASTER_PATH", master_path)
+    history_dir = tmp_path / "history"
+    monkeypatch.setattr(aggregate, "HISTORY_DIR", history_dir)
+
+    aggregate.aggregate()
+
+    assert master_path.exists()
+    data = orjson.loads(master_path.read_bytes())
+    assert len(data) == 2
+    assert not history_dir.exists()
+
+
+def test_backup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    create_meta_file(meta_dir, "c")
+    monkeypatch.setattr(aggregate, "META_DIR", meta_dir)
+    master_path = tmp_path / "master.json"
+    master_path.write_text("old")
+    monkeypatch.setattr(aggregate, "MASTER_PATH", master_path)
+    history_dir = tmp_path / "history"
+    monkeypatch.setattr(aggregate, "HISTORY_DIR", history_dir)
+
+    class DummyDT:
+        @classmethod
+        def utcnow(cls) -> datetime:
+            return datetime(2024, 5, 15, 13, 45, 0)
+
+    monkeypatch.setattr(aggregate, "datetime", DummyDT)
+
+    aggregate.aggregate()
+
+    backup = history_dir / "master_20240515T134500.json"
+    assert backup.exists()
+    assert backup.read_text() == "old"


### PR DESCRIPTION
## Summary
- add an `aggregate.py` script to collate metadata and handle backups
- back up existing `master.json` with timestamped copies
- test aggregation and backup logic

## Testing
- `black aggregate.py tests/test_aggregate.py`
- `ruff check aggregate.py tests/test_aggregate.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861453941288324a3a904fe95b9d88a