### PR TITLE
Implement master.json backup in aggregator

### DIFF
--- a/aggregate.py
+++ b/aggregate.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+import orjson
+
+from schemas.metadata import PaperMetadata
+
+ROOT = Path(__file__).resolve().parent
+META_DIR = ROOT / "data" / "meta"
+MASTER_PATH = ROOT / "data" / "master.json"
+HISTORY_DIR = ROOT / "data" / "master_history"
+
+
+def aggregate_metadata(
+    meta_dir: Path | None = None,
+    master_path: Path | None = None,
+    history_dir: Path | None = None,
+) -> List[PaperMetadata]:
+    meta_dir = meta_dir or META_DIR
+    master_path = master_path or MASTER_PATH
+    history_dir = history_dir or HISTORY_DIR
+
+    records: List[PaperMetadata] = []
+    for file in sorted(meta_dir.glob("*.json")):
+        try:
+            data = orjson.loads(file.read_bytes())
+            record = PaperMetadata.model_validate(data)
+            records.append(record)
+        except Exception:
+            continue
+
+    history_dir.mkdir(parents=True, exist_ok=True)
+    if master_path.exists():
+        timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+        backup = history_dir / f"master_{timestamp}.json"
+        backup.write_bytes(master_path.read_bytes())
+
+    master_path.write_bytes(orjson.dumps([r.model_dump() for r in records]))
+    return records
+
+
+if __name__ == "__main__":
+    aggregate_metadata()

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import orjson
+
+from aggregate import aggregate_metadata
+
+
+def create_meta(path: Path, name: str, data: dict) -> None:
+    file = path / f"{name}.json"
+    file.write_bytes(orjson.dumps(data))
+
+
+def test_aggregate_creates_master(tmp_path: Path) -> None:
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    create_meta(meta_dir, "a", {"title": "A"})
+    master_path = tmp_path / "master.json"
+    history_dir = tmp_path / "master_history"
+
+    aggregate_metadata(
+        meta_dir=meta_dir, master_path=master_path, history_dir=history_dir
+    )
+    assert master_path.exists()
+    data = orjson.loads(master_path.read_bytes())
+    assert data == [
+        {
+            "title": "A",
+            "authors": None,
+            "doi": None,
+            "pub_date": None,
+            "data_sources": None,
+            "omics_modalities": None,
+            "targets": None,
+            "p_threshold": None,
+            "ld_r2": None,
+        }
+    ]
+
+
+def test_aggregate_backup(tmp_path: Path) -> None:
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    create_meta(meta_dir, "a", {"title": "A"})
+    master_path = tmp_path / "master.json"
+    history_dir = tmp_path / "master_history"
+
+    aggregate_metadata(
+        meta_dir=meta_dir, master_path=master_path, history_dir=history_dir
+    )
+    first = master_path.read_bytes()
+
+    create_meta(meta_dir, "b", {"title": "B"})
+    aggregate_metadata(
+        meta_dir=meta_dir, master_path=master_path, history_dir=history_dir
+    )
+
+    backups = list(history_dir.glob("master_*.json"))
+    assert len(backups) == 1
+    assert backups[0].read_bytes() == first


### PR DESCRIPTION
## Summary
- add an `aggregate.py` script that collects metadata JSON files
- implement incremental backup when overwriting `data/master.json`
- cover the new backup logic with unit tests

## Testing
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861453941288324a3a904fe95b9d88a