### PR TITLE
Implement master.json backup on aggregation

### DIFF
--- a/aggregate.py
+++ b/aggregate.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+import logging
+import orjson
+from pydantic import ValidationError
+
+from schemas.metadata import PaperMetadata
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+META_DIR = DATA_DIR / "meta"
+MASTER_PATH = DATA_DIR / "master.json"
+HISTORY_DIR = DATA_DIR / "master_history"
+ERROR_LOG = DATA_DIR / "aggregation_errors.log"
+
+
+def _log_error(path: Path, exc: Exception) -> None:
+    timestamp = datetime.utcnow().isoformat()
+    msg = f'[{timestamp}] Invalid JSON in file {path}: "{exc}"\n'
+    ERROR_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with ERROR_LOG.open("a") as f:
+        f.write(msg)
+    logging.error("Invalid JSON in file %s: %s", path, exc)
+
+
+def _load_metadata() -> List[PaperMetadata]:
+    META_DIR.mkdir(parents=True, exist_ok=True)
+    records: List[PaperMetadata] = []
+    for path in sorted(META_DIR.glob("*.json")):
+        try:
+            data = orjson.loads(path.read_bytes())
+            record = PaperMetadata.model_validate(data)
+        except (orjson.JSONDecodeError, ValidationError) as exc:
+            _log_error(path, exc)
+            continue
+        records.append(record)
+    return records
+
+
+def _backup_master() -> None:
+    if MASTER_PATH.exists():
+        HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+        backup = HISTORY_DIR / f"master_{timestamp}.json"
+        backup.write_bytes(MASTER_PATH.read_bytes())
+
+
+def aggregate_metadata() -> List[PaperMetadata]:
+    records = _load_metadata()
+    _backup_master()
+    MASTER_PATH.write_bytes(
+        orjson.dumps([r.model_dump() for r in records], option=orjson.OPT_INDENT_2)
+    )
+    return records
+
+
+if __name__ == "__main__":
+    aggregate_metadata()

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,85 @@
+from datetime import datetime
+from pathlib import Path
+
+import orjson
+import pytest
+
+import aggregate
+from schemas.metadata import PaperMetadata
+
+
+def create_meta_file(dir_path: Path, name: str) -> None:
+    data = PaperMetadata(title=name).model_dump()
+    (dir_path / f"{name}.json").write_bytes(orjson.dumps(data))
+
+
+def test_aggregate_creates_master(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    create_meta_file(meta_dir, "a")
+    create_meta_file(meta_dir, "b")
+    monkeypatch.setattr(aggregate, "META_DIR", meta_dir)
+    master_path = tmp_path / "master.json"
+    monkeypatch.setattr(aggregate, "MASTER_PATH", master_path)
+    history_dir = tmp_path / "history"
+    monkeypatch.setattr(aggregate, "HISTORY_DIR", history_dir)
+
+    aggregate.aggregate_metadata()
+
+    assert master_path.exists()
+    data = orjson.loads(master_path.read_bytes())
+    assert len(data) == 2
+    assert not history_dir.exists()
+
+
+def test_backup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    create_meta_file(meta_dir, "c")
+    monkeypatch.setattr(aggregate, "META_DIR", meta_dir)
+    master_path = tmp_path / "master.json"
+    master_path.write_text("old")
+    monkeypatch.setattr(aggregate, "MASTER_PATH", master_path)
+    history_dir = tmp_path / "history"
+    monkeypatch.setattr(aggregate, "HISTORY_DIR", history_dir)
+
+    class DummyDT:
+        @classmethod
+        def utcnow(cls) -> datetime:
+            return datetime(2024, 5, 15, 13, 45, 0)
+
+    monkeypatch.setattr(aggregate, "datetime", DummyDT)
+
+    aggregate.aggregate_metadata()
+
+    backup = history_dir / "master_20240515T134500.json"
+    assert backup.exists()
+    assert backup.read_text() == "old"
+
+
+def test_invalid_json_logs_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    valid = PaperMetadata(title="t").model_dump()
+    (meta_dir / "valid.json").write_bytes(orjson.dumps(valid))
+    (meta_dir / "bad.json").write_text("{invalid}")
+
+    monkeypatch.setattr(aggregate, "META_DIR", meta_dir)
+    master_path = tmp_path / "master.json"
+    monkeypatch.setattr(aggregate, "MASTER_PATH", master_path)
+    history_dir = tmp_path / "history"
+    monkeypatch.setattr(aggregate, "HISTORY_DIR", history_dir)
+    log_path = tmp_path / "err.log"
+    monkeypatch.setattr(aggregate, "ERROR_LOG", log_path)
+
+    aggregate.aggregate_metadata()
+
+    assert master_path.exists()
+    data = orjson.loads(master_path.read_bytes())
+    assert len(data) == 1
+    assert log_path.exists()
+    assert "bad.json" in log_path.read_text()


### PR DESCRIPTION
## Summary
- unify aggregator script with error logging and backup support
- update tests to cover aggregation logging and backups

## Testing
- `black aggregate.py tests/test_aggregate.py`
- `ruff check aggregate.py tests/test_aggregate.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6861453941288324a3a904fe95b9d88a