### PR TITLE
Add CLI aggregation output and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ python agent1/metadata_extractor.py
 ```bash
 python aggregate.py
 ```
+This command reports how many files were aggregated and any that were skipped due
+to validation errors.
 
 5. Generate narrative reviews with Agent 2:
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,42 +1,88 @@
 import orjson
-from aggregator import aggregate_metadata
+from datetime import datetime
+from pathlib import Path
+import pytest
+
+import aggregate
+from schemas.metadata import PaperMetadata
 
 
-def valid_data():
-    return {
-        "title": "T",
-        "authors": "A",
-        "doi": "10.1/abc",
-        "pub_date": None,
-        "data_sources": None,
-        "omics_modalities": None,
-        "targets": None,
-        "p_threshold": None,
-        "ld_r2": None,
-    }
+def create_meta_file(dir_path: Path, name: str) -> None:
+    data = PaperMetadata(title=name).model_dump()
+    (dir_path / f"{name}.json").write_bytes(orjson.dumps(data))
 
 
-def test_aggregate_with_invalid_json(tmp_path, monkeypatch):
+def test_successful_aggregation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     meta_dir = tmp_path / "meta"
     meta_dir.mkdir()
+    create_meta_file(meta_dir, "a")
+    create_meta_file(meta_dir, "b")
+
+    monkeypatch.setattr(aggregate, "META_DIR", meta_dir)
     master = tmp_path / "master.json"
-    error_log = tmp_path / "aggregation_errors.log"
+    monkeypatch.setattr(aggregate, "MASTER_PATH", master)
+    history = tmp_path / "history"
+    monkeypatch.setattr(aggregate, "HISTORY_DIR", history)
 
-    monkeypatch.setattr("aggregator.META_DIR", meta_dir)
-    monkeypatch.setattr("aggregator.MASTER_PATH", master)
-    monkeypatch.setattr("aggregator.ERROR_LOG", error_log)
+    records, skipped, backup = aggregate.aggregate_metadata()
 
-    # valid file
-    (meta_dir / "valid.json").write_bytes(orjson.dumps(valid_data()))
-    # invalid file (wrong type)
-    (meta_dir / "invalid.json").write_bytes(orjson.dumps({"title": 1}))
-
-    results = aggregate_metadata()
-
-    assert len(results) == 1
+    assert len(records) == 2
+    assert skipped == 0
+    assert backup is None
     assert master.exists()
     data = orjson.loads(master.read_bytes())
-    assert len(data) == 1
-    assert error_log.exists()
-    log_content = error_log.read_text()
-    assert "invalid.json" in log_content
+    assert len(data) == 2
+
+
+def test_invalid_json_handling(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    create_meta_file(meta_dir, "valid")
+    (meta_dir / "bad.json").write_text("{invalid}")
+
+    monkeypatch.setattr(aggregate, "META_DIR", meta_dir)
+    master = tmp_path / "master.json"
+    monkeypatch.setattr(aggregate, "MASTER_PATH", master)
+    history = tmp_path / "history"
+    monkeypatch.setattr(aggregate, "HISTORY_DIR", history)
+    log_path = tmp_path / "err.log"
+    monkeypatch.setattr(aggregate, "ERROR_LOG", log_path)
+
+    records, skipped, backup = aggregate.aggregate_metadata()
+
+    assert len(records) == 1
+    assert skipped == 1
+    assert backup is None
+    assert master.exists()
+    assert log_path.exists()
+    assert "bad.json" in log_path.read_text()
+
+
+def test_backup_creation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    create_meta_file(meta_dir, "only")
+
+    monkeypatch.setattr(aggregate, "META_DIR", meta_dir)
+    master = tmp_path / "master.json"
+    master.write_text("old")
+    monkeypatch.setattr(aggregate, "MASTER_PATH", master)
+    history = tmp_path / "history"
+    monkeypatch.setattr(aggregate, "HISTORY_DIR", history)
+
+    class DummyDT:
+        @classmethod
+        def utcnow(cls) -> datetime:
+            return datetime(2024, 5, 15, 13, 45, 0)
+
+    monkeypatch.setattr(aggregate, "datetime", DummyDT)
+
+    records, skipped, backup = aggregate.aggregate_metadata()
+
+    assert skipped == 0
+    expected = history / "master_20240515T134500.json"
+    assert backup == expected
+    assert expected.exists()
+    assert expected.read_text() == "old"


### PR DESCRIPTION
## Summary
- expose aggregation stats via a new CLI in `aggregate.py`
- adjust aggregation helpers to return skipped counts and backups
- expand unit tests covering aggregation logic
- note CLI output in the README

## Testing
- `black .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68614ab52b2c832492270211552222ed