### PR TITLE
Add retrieval helper module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project automates the extraction and synthesis of structured information fr
 - **Text Extraction**: Conversion of PDFs to structured, page-wise text files.
 - **Metadata Extraction (Agent 1)**: Uses the OpenAI API to pull key metadata fields into JSON.
 - **Data Aggregation**: Collates individual metadata JSON files into a master dataset.
+- **Text Retrieval Helper**: Fetches keyword-based snippets from stored PDF text files for downstream RAG tasks.
 
 ## Features Under Development
 - **Narrative Review Generation (Agent 2)**: Planned support for creating narrative reviews from the aggregated data and extracted text.

--- a/agent2/retrieval.py
+++ b/agent2/retrieval.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import List
+
+import orjson
+
+TEXT_DIR = Path(__file__).resolve().parents[1] / "data" / "text"
+
+
+def _safe_name(doi: str) -> str:
+    return doi.replace("/", "_").replace(":", "_")
+
+
+def load_pages(doi: str) -> List[dict]:
+    path = TEXT_DIR / f"{_safe_name(doi)}.json"
+    if not path.exists():
+        return []
+    data = orjson.loads(path.read_bytes())
+    return data.get("pages", [])
+
+
+def get_snippets(doi: str, keyword: str, *, window: int = 40) -> List[str]:
+    pages = load_pages(doi)
+    pattern = re.compile(re.escape(keyword), re.IGNORECASE)
+    results: List[str] = []
+    for page in pages:
+        text = page.get("text", "")
+        for match in pattern.finditer(text):
+            start = max(match.start() - window, 0)
+            end = min(match.end() + window, len(text))
+            snippet = text[start:end].strip()
+            results.append(f"Page {page.get('page')}: {snippet}")
+    return results

--- a/tests/agent2/test_retrieval.py
+++ b/tests/agent2/test_retrieval.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import orjson
+
+import agent2.retrieval as retrieval
+
+
+def create_text_file(dir_path: Path, doi: str) -> Path:
+    pages = [
+        {"page": 1, "text": "This study uses Mendelian randomization techniques."},
+        {"page": 2, "text": "Further analysis is presented here."},
+    ]
+    data = {"pages": pages}
+    path = dir_path / f"{doi.replace('/', '_')}.json"
+    path.write_bytes(orjson.dumps(data))
+    return path
+
+
+def test_successful_snippet_retrieval(tmp_path: Path, monkeypatch) -> None:
+    text_dir = tmp_path / "text"
+    text_dir.mkdir()
+    create_text_file(text_dir, "10.1/abc")
+    monkeypatch.setattr(retrieval, "TEXT_DIR", text_dir)
+
+    result = retrieval.get_snippets("10.1/abc", "mendelian")
+    assert result
+    assert any("Page 1" in s for s in result)
+
+
+def test_no_matches(tmp_path: Path, monkeypatch) -> None:
+    text_dir = tmp_path / "text"
+    text_dir.mkdir()
+    create_text_file(text_dir, "10.2/xyz")
+    monkeypatch.setattr(retrieval, "TEXT_DIR", text_dir)
+
+    result = retrieval.get_snippets("10.2/xyz", "unrelated")
+    assert result == []


### PR DESCRIPTION
## Summary
- add `retrieval.py` in agent2 for keyword-based snippet lookup
- implement unit tests for retrieval helper
- document retrieval helper in README

## Testing
- `black .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68614c8561908324b92f6f2c1b786cc8