### PR TITLE
Add markdown lint workflow

### DIFF
--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -1,0 +1,18 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'outputs/*.md'
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install -g markdownlint-cli
+      - run: markdownlint outputs/*.md

--- a/README.md
+++ b/README.md
@@ -64,3 +64,6 @@ python agent2/synthesiser.py
 ## Contributing
 Contributions are welcome! Fork the repository and submit a pull request with improvements or new features.
 
+## Continuous Integration
+A GitHub Actions workflow automatically lints Markdown files in the `outputs/` directory on pull requests to the `main` branch.
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for markdown linting of `/outputs/*.md`
- document the new CI task in `README.md`

## Testing
- `black .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68614c9a4c108324a14ce7a907a4f5dd