### PR TITLE
Implement narrative generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ This project automates the extraction and synthesis of structured information fr
 - **Metadata Extraction (Agent 1)**: Uses the OpenAI API to pull key metadata fields into JSON.
 - **Data Aggregation**: Collates individual metadata JSON files into a master dataset.
 - **Text Retrieval Helper**: Fetches keyword-based snippets from stored PDF text files for downstream RAG tasks.
+- **Narrative Review Generation (Agent 2)**: Generates peer-review style summaries using `agent2/openai_narrative.py`.
 
 ## Features Under Development
-- **Narrative Review Generation (Agent 2)**: Prompt template available in `prompts/agent2_system.txt`; full automation is still under development.
+None at this time.
 
 ## Installation
 Clone the repository and create a virtual environment:
@@ -51,10 +52,15 @@ python aggregate.py
 This command reports how many files were aggregated and any that were skipped due
 to validation errors.
 
-5. Generate narrative reviews with Agent 2:
+5. Generate narrative reviews with Agent 2 programmatically:
 
-```bash
-python agent2/synthesiser.py
+```python
+from agent2.openai_narrative import OpenAINarrative
+
+generator = OpenAINarrative()
+metadata = ...  # load master.json
+snippets = ...  # collect text snippets
+narrative = generator.generate(metadata, snippets)
 ```
 The system prompt for this agent lives in `prompts/agent2_system.txt`.
 

--- a/agent2/narrative_validator.py
+++ b/agent2/narrative_validator.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+
+SECTIONS: Sequence[str] = [
+    "Search Overview",
+    "Data Sources for Instrument Selection",
+    "Differences in QTL Target",
+    "SNP Selection Criteria and LD Clumping Thresholds",
+    "Pleiotropy Checks and Sensitivity Analysis",
+    "Final Assessment of Study Quality and Reliability",
+]
+
+
+def validate(markdown: str) -> bool:
+    """Return True if ``markdown`` contains all required section headers."""
+    pos = 0
+    for title in SECTIONS:
+        pattern = rf"^## {re.escape(title)}\s*$"
+        match = re.search(pattern, markdown, flags=re.MULTILINE)
+        if not match or match.start() < pos:
+            return False
+        pos = match.end()
+    return True

--- a/agent2/openai_narrative.py
+++ b/agent2/openai_narrative.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+import time
+import orjson
+
+# openai imported lazily for tests
+import openai
+
+PROMPT_PATH = Path(__file__).resolve().parents[1] / "prompts" / "agent2_system.txt"
+
+
+class OpenAINarrative:
+    """Helper for generating narrative reviews using OpenAI."""
+
+    def __init__(self, model: str = "gpt-4-0125-preview") -> None:
+        self.model = model
+        self.prompt = PROMPT_PATH.read_text()
+
+    @staticmethod
+    def _format_input(metadata: List[Dict], snippets: List[str]) -> str:
+        meta_json = orjson.dumps(metadata, option=orjson.OPT_INDENT_2).decode()
+        snippet_text = "\n".join(f"- {s}" for s in snippets)
+        return f"Metadata:\n```json\n{meta_json}\n```\n\nSnippets:\n{snippet_text}"
+
+    def generate(
+        self, metadata: List[Dict], snippets: List[str], *, max_retries: int = 2
+    ) -> str:
+        """Generate a narrative review from ``metadata`` and ``snippets``."""
+        messages = [
+            {"role": "system", "content": self.prompt},
+            {"role": "user", "content": self._format_input(metadata, snippets)},
+        ]
+        delay = 1.0
+        for attempt in range(max_retries + 1):
+            try:
+                response = openai.ChatCompletion.create(
+                    model=self.model, messages=messages
+                )
+                content = response["choices"][0]["message"]["content"]
+                return content
+            except Exception:
+                if attempt >= max_retries:
+                    raise
+                time.sleep(delay)
+                delay *= 2
+        raise RuntimeError("Failed to obtain narrative from OpenAI")

--- a/tests/agent2/test_openai_narrative.py
+++ b/tests/agent2/test_openai_narrative.py
@@ -1,0 +1,61 @@
+import sys
+import types
+from pathlib import Path
+
+
+# Setup fake openai module before import
+fake_openai = types.ModuleType("openai")
+
+
+class FakeChatCompletion:
+    def __init__(self):
+        self.calls = []
+        self.responses = []
+
+    def create(self, *args, **kwargs):
+        self.calls.append({"args": args, "kwargs": kwargs})
+        resp = self.responses.pop(0)
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+
+fake_chat = FakeChatCompletion()
+fake_openai.ChatCompletion = fake_chat
+sys.modules["openai"] = fake_openai
+
+from agent2.openai_narrative import OpenAINarrative  # noqa: E402
+
+
+def setup_prompt(tmp_path: Path) -> Path:
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    path = prompt_dir / "agent2_system.txt"
+    path.write_text("Prompt")
+    return path
+
+
+def test_success(monkeypatch, tmp_path):
+    path = setup_prompt(tmp_path)
+    monkeypatch.setattr("agent2.openai_narrative.PROMPT_PATH", path)
+    fake_chat.calls.clear()
+    fake_chat.responses = [{"choices": [{"message": {"content": "done"}}]}]
+    gen = OpenAINarrative(model="test")
+    result = gen.generate([{"title": "T"}], ["s1"])
+    assert result == "done"
+    assert len(fake_chat.calls) == 1
+
+
+def test_retry(monkeypatch, tmp_path):
+    path = setup_prompt(tmp_path)
+    monkeypatch.setattr("agent2.openai_narrative.PROMPT_PATH", path)
+    fake_chat.calls.clear()
+    fake_chat.responses = [
+        RuntimeError("bad"),
+        {"choices": [{"message": {"content": "ok"}}]},
+    ]
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    gen = OpenAINarrative(model="test")
+    result = gen.generate([{"title": "T"}], ["s1"])
+    assert result == "ok"
+    assert len(fake_chat.calls) == 2


### PR DESCRIPTION
## Summary
- implement `OpenAINarrative` for OpenAI calls
- add narrative markdown validator
- document narrative generator usage in README
- test narrative generation helper

## Testing
- `black . --quiet`
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68614e868e30832497d49a9c916c584f