### PR TITLE
Add synthesiser CLI and integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ narrative = generator.generate(metadata, snippets)
 ```
 The system prompt for this agent lives in `prompts/agent2_system.txt`.
 
+Alternatively, run the CLI to produce a review for a specific drug:
+
+```bash
+python agent2/synthesiser.py --drug <drugname>
+```
+
 ## Output
 - Individual metadata JSONs in `data/meta/`.
 - Aggregated metadata in `data/master.json`.

--- a/agent2/synthesiser.py
+++ b/agent2/synthesiser.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List, Dict
+
+import orjson
+
+from agent2 import retrieval
+from agent2.openai_narrative import OpenAINarrative
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+MASTER_PATH = DATA_DIR / "master.json"
+OUTPUT_DIR = Path(__file__).resolve().parents[1] / "outputs"
+
+
+def load_master() -> List[Dict]:
+    """Load and return list of metadata records from ``master.json``."""
+    if not MASTER_PATH.exists():
+        raise FileNotFoundError(f"Master file not found: {MASTER_PATH}")
+    data = orjson.loads(MASTER_PATH.read_bytes())
+    if not isinstance(data, list):
+        raise ValueError("master.json must contain a list")
+    return data
+
+
+def filter_by_drug(records: List[Dict], drug: str) -> List[Dict]:
+    """Return records where ``drug`` is listed in ``targets``."""
+    result: List[Dict] = []
+    for rec in records:
+        targets = rec.get("targets") or []
+        if any(drug.lower() == str(t).lower() for t in targets):
+            result.append(rec)
+    return result
+
+
+def collect_snippets(records: List[Dict], drug: str) -> List[str]:
+    snippets: List[str] = []
+    for rec in records:
+        doi = rec.get("doi")
+        if doi:
+            snippets.extend(retrieval.get_snippets(doi, drug))
+    return snippets
+
+
+def synthesise(drug: str) -> Path:
+    """Generate a narrative review for ``drug`` and return output path."""
+    records = filter_by_drug(load_master(), drug)
+    if not records:
+        raise ValueError(f"No studies found for {drug}")
+    snippets = collect_snippets(records, drug)
+    generator = OpenAINarrative()
+    narrative = generator.generate(records, snippets)
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = OUTPUT_DIR / f"review_{drug.replace(' ', '_')}.md"
+    out_path.write_text(narrative)
+    return out_path
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate a narrative review")
+    parser.add_argument("--drug", required=True, help="Drug name")
+    args = parser.parse_args(argv)
+    try:
+        synthesise(args.drug)
+    except Exception as exc:
+        print(f"Error: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent2/test_synthesiser_cli.py
+++ b/tests/agent2/test_synthesiser_cli.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import orjson
+
+# Setup fake openai before importing synthesiser
+fake_openai = types.ModuleType("openai")
+sys.modules["openai"] = fake_openai
+
+import agent2.synthesiser as synthesiser  # noqa: E402
+
+
+class FakeNarrative:
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, metadata, snippets):
+        self.calls.append({"metadata": metadata, "snippets": snippets})
+        return "# Review"
+
+
+def create_master(tmp_path: Path) -> Path:
+    data = [
+        {"title": "A", "doi": "10.1/a", "targets": ["DrugX"]},
+        {"title": "B", "doi": "10.2/b", "targets": ["Other"]},
+    ]
+    path = tmp_path / "master.json"
+    path.write_bytes(orjson.dumps(data))
+    return path
+
+
+def test_cli_success(monkeypatch, tmp_path: Path) -> None:
+    master = create_master(tmp_path)
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(synthesiser, "MASTER_PATH", master)
+    monkeypatch.setattr(synthesiser, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(synthesiser, "OpenAINarrative", FakeNarrative)
+    monkeypatch.setattr(synthesiser.retrieval, "get_snippets", lambda doi, kw: [f"s-{doi}"])  # type: ignore
+
+    code = synthesiser.main(["--drug", "DrugX"])
+    assert code == 0
+    out_file = out_dir / "review_DrugX.md"
+    assert out_file.exists()
+    assert out_file.read_text() == "# Review"
+
+
+def test_no_data(monkeypatch, tmp_path: Path) -> None:
+    master = create_master(tmp_path)
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(synthesiser, "MASTER_PATH", master)
+    monkeypatch.setattr(synthesiser, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(synthesiser, "OpenAINarrative", FakeNarrative)
+
+    code = synthesiser.main(["--drug", "Missing"])
+    assert code == 1
+    assert not out_dir.exists()
+
+
+def test_empty_snippets(monkeypatch, tmp_path: Path) -> None:
+    master = create_master(tmp_path)
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(synthesiser, "MASTER_PATH", master)
+    monkeypatch.setattr(synthesiser, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(synthesiser, "OpenAINarrative", FakeNarrative)
+    monkeypatch.setattr(synthesiser.retrieval, "get_snippets", lambda doi, kw: [])  # type: ignore
+
+    code = synthesiser.main(["--drug", "DrugX"])
+    assert code == 0
+    out_file = out_dir / "review_DrugX.md"
+    assert out_file.exists()
+    assert out_file.read_text() == "# Review"


### PR DESCRIPTION
## Summary
- implement `agent2/synthesiser.py` CLI for generating narrative reviews
- add integration tests for the synthesiser CLI
- document CLI usage in `README.md`

## Testing
- `black .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68614fc01c508324986b661bfefd166b