### PR TITLE
Add end-to-end pipeline runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ narrative = generator.generate(metadata, snippets)
 ```
 The system prompt for this agent lives in `prompts/agent2_system.txt`.
 
+6. Run the entire pipeline in one step:
+
+```bash
+python pipeline.py --pdf-dir data/pdfs --drug <drug-name>
+```
+
 ## Output
 - Individual metadata JSONs in `data/meta/`.
 - Aggregated metadata in `data/master.json`.

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import orjson
+
+from ingest.collector import ingest_pdf
+from extract.pdf_to_text import pdf_to_text, DATA_DIR as TEXT_DIR
+from agent1.metadata_extractor import MetadataExtractor
+import aggregate
+from agent2.openai_narrative import OpenAINarrative
+from agent2 import retrieval
+
+OUTPUT_DIR = Path(__file__).resolve().parent / "outputs"
+
+
+def ingest_pdfs(pdf_dir: str) -> List[Path]:
+    """Ingest all PDFs in *pdf_dir* and extract their text."""
+    paths = []
+    for pdf_path in sorted(Path(pdf_dir).glob("*.pdf")):
+        entry = ingest_pdf(pdf_path)
+        if entry is not None:
+            paths.append(pdf_path)
+        pdf_to_text(pdf_path)
+    return paths
+
+
+def extract_metadata_from_text() -> List[Path]:
+    """Run Agent 1 on all text files in ``TEXT_DIR``."""
+    extractor = MetadataExtractor()
+    results = []
+    for text_path in sorted(TEXT_DIR.glob("*.json")):
+        meta = extractor.extract(text_path)
+        if meta is not None:
+            results.append(text_path)
+    return results
+
+
+def generate_narrative(drug_name: str) -> Path:
+    """Generate a narrative review from ``master.json`` using ``drug_name``."""
+    master_path = aggregate.MASTER_PATH
+    if not master_path.exists():
+        raise FileNotFoundError("master.json not found. Run aggregation first.")
+    metadata = orjson.loads(master_path.read_bytes())
+    snippets: List[str] = []
+    for record in metadata:
+        doi = record.get("doi")
+        if doi:
+            snippets.extend(retrieval.get_snippets(doi, drug_name))
+    narrative = OpenAINarrative().generate(metadata, snippets)
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    out_file = OUTPUT_DIR / f"{drug_name.replace(' ', '_')}_review.md"
+    out_file.write_text(narrative)
+    return out_file
+
+
+def run_pipeline(pdf_dir: str, drug_name: str) -> None:
+    """Execute the full data processing pipeline."""
+    ingest_pdfs(pdf_dir)
+    extract_metadata_from_text()
+    aggregate.aggregate_metadata()
+    generate_narrative(drug_name)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the full pipeline")
+    parser.add_argument("--pdf-dir", required=True, help="Directory with PDFs")
+    parser.add_argument("--drug", required=True, help="Drug name for snippets")
+    args = parser.parse_args()
+
+    run_pipeline(args.pdf_dir, args.drug)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+import pipeline
+from schemas.metadata import PaperMetadata
+
+
+def create_pdf(path: Path) -> None:
+    c = canvas.Canvas(str(path), pagesize=letter)
+    c.drawString(100, 750, "Hello")
+    c.showPage()
+    c.save()
+
+
+def valid_metadata() -> dict:
+    return {
+        "title": "T",
+        "authors": "A",
+        "doi": "10.1/test",
+        "pub_date": None,
+        "data_sources": None,
+        "omics_modalities": None,
+        "targets": None,
+        "p_threshold": None,
+        "ld_r2": None,
+    }
+
+
+class FakeNarrative:
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, metadata, snippets):
+        self.calls.append((metadata, snippets))
+        return "review"
+
+
+def test_run_pipeline(monkeypatch, tmp_path):
+    pdf_dir = tmp_path / "pdfs"
+    pdf_dir.mkdir()
+    pdf = pdf_dir / "paper.pdf"
+    create_pdf(pdf)
+
+    log_path = tmp_path / "log.jsonl"
+    monkeypatch.setattr("ingest.collector.LOG_PATH", log_path)
+    monkeypatch.setattr("extract.pdf_to_text.DATA_DIR", tmp_path / "text")
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+    monkeypatch.setattr(
+        "agent1.metadata_extractor.MetadataExtractor.extract",
+        lambda self, _path: PaperMetadata(**valid_metadata()),
+    )
+    monkeypatch.setattr("aggregate.META_DIR", tmp_path / "meta")
+    monkeypatch.setattr("aggregate.MASTER_PATH", tmp_path / "master.json")
+    monkeypatch.setattr("aggregate.HISTORY_DIR", tmp_path / "history")
+    monkeypatch.setattr("agent2.retrieval.TEXT_DIR", tmp_path / "text")
+    monkeypatch.setattr("pipeline.OUTPUT_DIR", tmp_path / "out")
+
+    fake = FakeNarrative()
+    monkeypatch.setattr("pipeline.OpenAINarrative", lambda: fake)
+
+    pipeline.run_pipeline(str(pdf_dir), "test")
+
+    assert (tmp_path / "master.json").exists()
+    out_file = tmp_path / "out" / "test_review.md"
+    assert out_file.exists()
+    assert fake.calls


### PR DESCRIPTION
## Summary
- add `pipeline.py` orchestrator with functions for ingestion through narrative generation
- document usage of the pipeline
- test the new pipeline functionality

## Testing
- `black pipeline.py tests/test_pipeline.py`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68615036d0d08324861c3e673863934e