### PR TITLE
Add standalone pipeline CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ narrative = generator.generate(metadata, snippets)
 The system prompt for this agent lives in `prompts/agent2_system.txt`.
 
 
-6. Run the entire pipeline in one step:
+6. Run the entire pipeline in one step using the CLI script:
 
 ```bash
-python pipeline.py --pdf-dir data/pdfs --drug <drug-name>
+python run_pipeline.py --pdf_dir data/pdfs --drug <drug-name>
 
 ```
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import argparse
+
+import pipeline
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the pipeline CLI."""
+    parser = argparse.ArgumentParser(description="Run MR literature pipeline.")
+    parser.add_argument("--pdf_dir", required=True, help="Directory containing PDFs")
+    parser.add_argument("--drug", required=True, help="Name of the drug for review")
+    args = parser.parse_args(argv)
+    pipeline.run_pipeline(args.pdf_dir, args.drug)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_run_pipeline_cli.py
+++ b/tests/test_run_pipeline_cli.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import run_pipeline
+
+
+def test_main_invokes_pipeline(monkeypatch):
+    calls = {}
+
+    def fake_run(pdf_dir: str, drug: str) -> None:
+        calls["pdf_dir"] = pdf_dir
+        calls["drug"] = drug
+
+    monkeypatch.setattr("pipeline.run_pipeline", fake_run)
+
+    code = run_pipeline.main(["--pdf_dir", "data/pdfs", "--drug", "rapa"])
+    assert code == 0
+    assert calls == {"pdf_dir": "data/pdfs", "drug": "rapa"}


### PR DESCRIPTION
## Summary
- add `run_pipeline.py` CLI for running the full pipeline
- document new script in README
- test CLI invocation

## Testing
- `ruff check run_pipeline.py tests/test_run_pipeline_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686151eba2248324afe9355e1838d8e3