### PR TITLE
Add CLI integration test with sample PDFs

### DIFF
--- a/tests/fixtures/sample_pdfs/sample1.pdf
+++ b/tests/fixtures/sample_pdfs/sample1.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250629145352+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250629145352+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 101
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CW4KISi90MjG^2,FS#<R;"HbUpn-<A;p%#g#sMd/p:HhuWo24qYm~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<31e0d8abe5a346fae45d28ccdbb28bc7><31e0d8abe5a346fae45d28ccdbb28bc7>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1028
+%%EOF

--- a/tests/fixtures/sample_pdfs/sample2.pdf
+++ b/tests/fixtures/sample_pdfs/sample2.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250629145352+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250629145352+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 101
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CW4KISi90MjG^2,FS#<R;"HbUpn-<A;j##g#sMd/p:HhuWo29G,D~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<3e9bb9b9f6a6d04a4f96387382e8a50a><3e9bb9b9f6a6d04a4f96387382e8a50a>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1028
+%%EOF

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import orjson
+from pathlib import Path
+
+import run_pipeline
+from schemas.metadata import PaperMetadata
+
+
+class FakeNarrative:
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[dict], list[str]]] = []
+
+    def generate(self, metadata: list[dict], snippets: list[str]) -> str:
+        self.calls.append((metadata, snippets))
+        return "# Review"
+
+
+class FakeExtractor:
+    def __init__(self) -> None:
+        self.calls: list[Path] = []
+
+    def extract(self, text_path: Path) -> PaperMetadata | None:
+        self.calls.append(text_path)
+        return PaperMetadata(title="T", doi="10.1/test")
+
+
+def test_full_pipeline_cli(monkeypatch, tmp_path: Path) -> None:
+    pdf_dir = Path("tests/fixtures/sample_pdfs")
+
+    monkeypatch.setattr("ingest.collector.LOG_PATH", tmp_path / "log.jsonl")
+    monkeypatch.setattr("extract.pdf_to_text.DATA_DIR", tmp_path / "text")
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+    monkeypatch.setattr("aggregate.META_DIR", tmp_path / "meta")
+    monkeypatch.setattr("aggregate.MASTER_PATH", tmp_path / "master.json")
+    monkeypatch.setattr("aggregate.HISTORY_DIR", tmp_path / "history")
+    monkeypatch.setattr("agent2.retrieval.TEXT_DIR", tmp_path / "text")
+    monkeypatch.setattr("pipeline.OUTPUT_DIR", tmp_path / "outputs")
+
+    extractor = FakeExtractor()
+    monkeypatch.setattr("pipeline.MetadataExtractor", lambda: extractor)
+    narrative = FakeNarrative()
+    monkeypatch.setattr("pipeline.OpenAINarrative", lambda: narrative)
+
+    code = run_pipeline.main(["--pdf_dir", str(pdf_dir), "--drug", "TestDrug"])
+    assert code == 0
+
+    master_path = tmp_path / "master.json"
+    assert master_path.exists()
+    data = orjson.loads(master_path.read_bytes())
+    assert isinstance(data, list)
+    for record in data:
+        PaperMetadata.model_validate(record)
+
+    out_file = tmp_path / "outputs" / "TestDrug_review.md"
+    assert out_file.exists()


### PR DESCRIPTION
## Summary
- add sample PDFs under `tests/fixtures/sample_pdfs`
- implement `tests/test_pipeline_integration.py` to run the pipeline via its CLI

## Testing
- `black .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686152eccb9c832486ff78d4dabac103