### PR TITLE
Add schema drift detection test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run Schema Drift Test
+        run: pytest tests/test_schema_drift.py

--- a/README.md
+++ b/README.md
@@ -83,4 +83,5 @@ Contributions are welcome! Fork the repository and submit a pull request with im
 
 ## Continuous Integration
 A GitHub Actions workflow automatically lints Markdown files in the `outputs/` directory on pull requests to the `main` branch.
+Another workflow runs a schema drift unit test to ensure that `PaperMetadata` does not change unexpectedly.
 

--- a/tests/test_schema_drift.py
+++ b/tests/test_schema_drift.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from schemas.metadata import PaperMetadata
+
+EXPECTED_KEYS = {
+    "title",
+    "authors",
+    "doi",
+    "pub_date",
+    "data_sources",
+    "omics_modalities",
+    "targets",
+    "p_threshold",
+    "ld_r2",
+}
+
+
+def test_metadata_schema_keys() -> None:
+    schema_keys = set(PaperMetadata.__annotations__.keys())
+    assert (
+        schema_keys == EXPECTED_KEYS
+    ), f"Schema drift detected: {schema_keys ^ EXPECTED_KEYS}"


### PR DESCRIPTION
## Summary
- add schema drift unit test to guard PaperMetadata schema
- integrate new test into GitHub Actions workflow
- document the new workflow in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68615459e5788324ad26ef2207439e59