### PR TITLE
Add telemetry and standardized logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ python run_pipeline.py --pdf_dir data/pdfs --drug <drug-name>
 - Generated narrative reviews in `outputs/`.
 - For instructions on processing a new drug, see `docs/HOW_TO_ADD_NEW_DRUG.md`.
 
+## Telemetry & Logging
+All components now emit standardized logs using Python's ``logging`` module. The
+logger records timestamps, module names and log levels. OpenAI API calls include
+timing information and token usage statistics to help estimate costs and detect
+rate-limit issues.
+
 ## Contributing
 Contributions are welcome! Fork the repository and submit a pull request with improvements or new features.
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import logging
+
+logging.basicConfig(
+    format="%(asctime)s [%(levelname)s] %(module)s: %(message)s",
+    level=logging.INFO,
+)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger with the specified *name*."""
+    return logging.getLogger(name)


### PR DESCRIPTION
## Summary
- implement central logger utility
- capture API call timing and token usage in agent1 and agent2
- log retries and failures for OpenAI interactions
- measure pipeline step durations
- document telemetry in README

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861548897f08324bd6844ab9e69a8ff