### PR TITLE
Add schema validation test and JSON validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,15 @@ python aggregate.py
 This command reports how many files were aggregated and any that were skipped due
 to validation errors.
 
-5. Generate narrative reviews with Agent 2 programmatically:
+5. Validate JSON integrity:
+
+```bash
+python utils/json_validator.py
+```
+This checks all files in `data/meta/` and `data/master.json` for UTF-8 encoding
+and valid JSON structure.
+
+6. Generate narrative reviews with Agent 2 programmatically:
 
 ```python
 from agent2.openai_narrative import OpenAINarrative

--- a/data/meta/sample1.json
+++ b/data/meta/sample1.json
@@ -1,0 +1,11 @@
+{
+  "title": "Study One",
+  "authors": "Doe, A.",
+  "doi": "10.1/abc",
+  "pub_date": "2024-01-01",
+  "data_sources": ["db1"],
+  "omics_modalities": ["genomics"],
+  "targets": ["Gene1"],
+  "p_threshold": "1e-5",
+  "ld_r2": "0.1"
+}

--- a/data/meta/sample2.json
+++ b/data/meta/sample2.json
@@ -1,0 +1,11 @@
+{
+  "title": "Study Two",
+  "authors": "Smith, B.",
+  "doi": "10.1/xyz",
+  "pub_date": "2023-12-15",
+  "data_sources": ["db2"],
+  "omics_modalities": ["transcriptomics"],
+  "targets": ["Gene2"],
+  "p_threshold": "1e-6",
+  "ld_r2": "0.2"
+}

--- a/tests/test_schema_drift.py
+++ b/tests/test_schema_drift.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+import orjson
+import pytest
+
+from schemas.metadata import PaperMetadata
+
+META_DIR = Path("data/meta")
+
+
+@pytest.mark.parametrize("path", sorted(META_DIR.glob("*.json")))
+def test_metadata_conforms_to_schema(path: Path) -> None:
+    data = orjson.loads(path.read_bytes())
+    PaperMetadata.model_validate(data)

--- a/utils/json_validator.py
+++ b/utils/json_validator.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+import orjson
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+META_DIR = DATA_DIR / "meta"
+MASTER_PATH = DATA_DIR / "master.json"
+
+
+def validate_file(path: Path) -> bool:
+    try:
+        raw = path.read_bytes()
+        raw.decode("utf-8")
+        orjson.loads(raw)
+    except Exception as exc:
+        print(f"Invalid JSON in {path}: {exc}")
+        return False
+    return True
+
+
+def main() -> int:
+    paths = list(META_DIR.glob("*.json"))
+    if MASTER_PATH.exists():
+        paths.append(MASTER_PATH)
+    if not paths:
+        print("No JSON files found.")
+        return 0
+    all_valid = True
+    for path in paths:
+        if not validate_file(path):
+            all_valid = False
+    if all_valid:
+        print("All JSON files are valid UTF-8 and well-formed.")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- create test_schema_drift to ensure metadata JSONs conform to PaperMetadata
- add a small set of sample metadata in `data/meta/`
- add `utils/json_validator.py` for validating JSON syntax and UTF-8 encoding
- document the validator in README

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`
- `python utils/json_validator.py`

------
https://chatgpt.com/codex/tasks/task_b_6861634a62dc8324908561c5d647c020