### PR TITLE
Add performance logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ python run_pipeline.py --pdf_dir data/pdfs --drug <drug-name>
 All components now emit standardized logs using Python's ``logging`` module. The
 logger records timestamps, module names and log levels. OpenAI API calls include
 timing information and token usage statistics to help estimate costs and detect
-rate-limit issues.
+rate-limit issues. The pipeline also logs the duration and memory delta of each
+major step so you can identify slow stages.
 
 ## Contributing
 Contributions are welcome! Fork the repository and submit a pull request with improvements or new features.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,44 @@
+# Pipeline Performance Report
+
+This document summarizes execution time and memory usage when running the
+pipeline on the sample PDFs located in `tests/fixtures/sample_pdfs`.
+
+## Metrics Collection
+
+`pipeline.py` now records the duration and memory delta for each major step using
+the standard `resource` module. After all steps complete, a summary is logged
+with steps sorted by runtime.
+
+## Sample Run
+
+A run using fake extractors on the two sample PDFs produced the following log:
+
+```
+2025-06-29 16:04:13,956 [INFO] pipeline: Ingestion completed in 0.01s (+256 KB)
+2025-06-29 16:04:13,956 [INFO] pipeline: Metadata Extraction completed in 0.00s (+0 KB)
+2025-06-29 16:04:13,956 [INFO] pipeline: Aggregation completed in 0.00s (+0 KB)
+2025-06-29 16:04:13,957 [INFO] pipeline: Narrative Generation completed in 0.00s (+0 KB)
+2025-06-29 16:04:13,957 [INFO] pipeline: -- Performance Summary --
+2025-06-29 16:04:13,957 [INFO] pipeline: Ingestion            0.01s +256 KB
+2025-06-29 16:04:13,957 [INFO] pipeline: Narrative Generation 0.00s +0 KB
+2025-06-29 16:04:13,957 [INFO] pipeline: Metadata Extraction  0.00s +0 KB
+2025-06-29 16:04:13,957 [INFO] pipeline: Aggregation          0.00s +0 KB
+```
+
+The ingestion stage, which includes PDF text extraction, was the slowest step in
+this small run.
+
+## Observations
+
+- **Ingestion** took noticeably longer than other steps, mostly due to PDF
+  processing with `pdfminer.six`.
+- Memory use remained low (under one megabyte increase for each step), and no
+  significant leaks were observed.
+
+## Optimization Ideas
+
+1. **Parallelize PDF processing** – using multiprocessing or threading could
+   speed up ingestion when many PDFs are present.
+2. **Cache intermediate text files** – skipping extraction when text already
+   exists would avoid redundant work.
+


### PR DESCRIPTION
## Summary
- record timing and memory metrics for each pipeline step
- document the new metrics and sample performance run
- mention performance logging in README

## Testing
- `ruff check pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68616358e57c832495e2a10662ea8c4a