### PR TITLE
Improve log clarity and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Install dependencies:
 
 ```bash
 pip install -r requirements.txt
+# The pipeline relies on the pre-1.0 OpenAI client
+pip install "openai<1.0"
+```
+
+Set your OpenAI API key in the ``OPENAI_API_KEY`` environment variable before running any pipeline steps:
+
+```bash
+export OPENAI_API_KEY=<your-key>
 ```
 
 ## Usage

--- a/agent1/metadata_extractor.py
+++ b/agent1/metadata_extractor.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Iterable, Optional, Union
 import orjson
 from pydantic import ValidationError
 
-from utils.logger import get_logger
+from utils.logger import get_logger, format_exception
 
 from agent1.openai_client import OpenAIJSONCaller
 from schemas.metadata import PaperMetadata
@@ -65,10 +65,10 @@ class MetadataExtractor:
             except (ValidationError, Exception) as exc:
                 duration = time.time() - start
                 logger.error(
-                    "Validation failed on attempt %s after %.2fs: %s",
+                    "Validation failed on attempt %s after %.2fs (%s)",
                     attempt + 1,
                     duration,
-                    exc,
+                    format_exception(exc),
                 )
                 usage = getattr(self.client, "last_usage", None)
                 if usage:

--- a/agent1/openai_client.py
+++ b/agent1/openai_client.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import orjson
 import time
 
-from utils.logger import get_logger
+from utils.logger import get_logger, format_exception
 
 # openai is imported lazily in tests via a stub if not installed
 import openai
@@ -43,10 +43,10 @@ class OpenAIJSONCaller:
             except Exception as exc:  # pragma: no cover - network errors
                 duration = time.time() - start_time
                 logger.error(
-                    "OpenAI request failed on attempt %s after %.2fs: %s",
+                    "OpenAI request failed on attempt %s after %.2fs (%s)",
                     attempt + 1,
                     duration,
-                    exc,
+                    format_exception(exc),
                 )
                 if attempt >= max_retries:
                     raise
@@ -68,7 +68,11 @@ class OpenAIJSONCaller:
             try:
                 result = orjson.loads(content)
             except orjson.JSONDecodeError as exc:
-                logger.error("JSON decode error on attempt %s: %s", attempt + 1, exc)
+                logger.error(
+                    "JSON decode error on attempt %s (%s)",
+                    attempt + 1,
+                    format_exception(exc),
+                )
                 if attempt >= max_retries:
                     raise
                 time.sleep(delay)

--- a/agent2/openai_narrative.py
+++ b/agent2/openai_narrative.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 import time
 import orjson
 
-from utils.logger import get_logger
+from utils.logger import get_logger, format_exception
 
 # openai imported lazily for tests
 import openai
@@ -47,10 +47,10 @@ class OpenAINarrative:
             except Exception as exc:  # pragma: no cover - network errors
                 duration = time.time() - start_time
                 logger.error(
-                    "Narrative generation failed on attempt %s after %.2fs: %s",
+                    "Narrative generation failed on attempt %s after %.2fs (%s)",
                     attempt + 1,
                     duration,
-                    exc,
+                    format_exception(exc),
                 )
                 if attempt >= max_retries:
                     raise

--- a/docs/HOW_TO_ADD_NEW_DRUG.md
+++ b/docs/HOW_TO_ADD_NEW_DRUG.md
@@ -13,6 +13,8 @@ Run the end-to-end pipeline from the repository root:
 python run_pipeline.py --pdf_dir data/new_pdfs --drug <your_drug_name>
 ```
 
+Make sure the ``OPENAI_API_KEY`` environment variable is set and that you installed ``openai<1.0``.
+
 This command ingests the PDFs, extracts text, gathers metadata, and generates a narrative review.
 
 ## Step 3: Check Outputs

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -8,6 +8,11 @@ logging.basicConfig(
 )
 
 
+def format_exception(exc: Exception) -> str:
+    """Return a concise representation of *exc* for logging."""
+    return f"{type(exc).__name__}: {str(exc).splitlines()[0]}"
+
+
 def get_logger(name: str) -> logging.Logger:
     """Return a logger with the specified *name*."""
     return logging.getLogger(name)


### PR DESCRIPTION
## Summary
- shorten error logs with `format_exception`
- mention OpenAI API key and pin `openai<1.0` in README
- update HOW_TO guide with same note

## Testing
- `black . --quiet`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861636734fc8324bc26da8e3de7ed6b