### PR TITLE
Fix OCR fallback when tesseract missing

### DIFF
--- a/extract/pdf_to_text.py
+++ b/extract/pdf_to_text.py
@@ -55,7 +55,11 @@ def pdf_to_text(path: str | Path) -> PDFText:
     texts = extract_text(pdf_path)
     blank_pages = sum(1 for t in texts if not t)
     if texts and blank_pages / len(texts) > 0.5:
-        if pytesseract.get_tesseract_version() is not None:
+        try:
+            pytesseract.get_tesseract_version()
+        except pytesseract.TesseractNotFoundError:
+            pass
+        else:
             texts = ocr_text(pdf_path, texts)
     data = PDFText(
         pages=[Page(page=i + 1, text=txt) for i, txt in enumerate(texts)],


### PR DESCRIPTION
## Summary
- prevent `pdf_to_text` from raising when tesseract isn't installed
- test the fallback logic for missing tesseract

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686184b30334832cabc4fb02a0674527