### PR TITLE
Add integration tests for provided PDFs

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,8 @@
+# Proposed Tasks
+
+The newly added integration tests in `tests/integration/test_real_pdfs.py` fail because `agent1.openai_client.OpenAIJSONCaller` reads its prompt using the platform default encoding. When the default is not UTF-8, `Path.read_text()` throws a `UnicodeDecodeError` for `prompts/agent1_prompt.txt`.
+
+## Task: enforce UTF-8 when loading prompts
+- Update `agent1/openai_client.py` to read `PROMPT_PATH` with `encoding="utf-8"`.
+- Add a similar explicit encoding in `agent2/openai_narrative.py`.
+- Verify that the integration tests pass after these changes.

--- a/tests/integration/test_real_pdfs.py
+++ b/tests/integration/test_real_pdfs.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+import pytest
+
+from ingest.collector import ingest_pdf
+from extract.pdf_to_text import pdf_to_text
+
+
+class FakeClient:
+    def __init__(self, response):
+        self.response = response
+
+    def call(self, text, *, max_retries=2):
+        return self.response
+
+
+def valid_metadata() -> dict:
+    return {
+        "title": "T",
+        "authors": "A",
+        "doi": "10.1/test",
+        "pub_date": None,
+        "data_sources": None,
+        "omics_modalities": None,
+        "targets": None,
+        "p_threshold": None,
+        "ld_r2": None,
+    }
+
+
+@pytest.mark.parametrize("pdf_path", sorted(Path("data/pdfs").glob("*.pdf")))
+def test_pdf_to_text_real_files(
+    tmp_path: Path, pdf_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("extract.pdf_to_text.DATA_DIR", tmp_path)
+    ingest_pdf(pdf_path)
+    result = pdf_to_text(pdf_path)
+    assert result.pages
+
+
+@pytest.mark.parametrize("pdf_path", sorted(Path("data/pdfs").glob("*.pdf")))
+def test_metadata_extractor_prompt_decode_error(
+    tmp_path: Path, pdf_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("extract.pdf_to_text.DATA_DIR", tmp_path / "text")
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+    pdf_to_text(pdf_path)
+
+    import agent1.openai_client as oc
+
+    original_read_text = oc.Path.read_text
+
+    def cp1252_read_text(self, *args, **kwargs):
+        return original_read_text(self, encoding="cp1252")
+
+    monkeypatch.setattr(oc.Path, "read_text", cp1252_read_text)
+
+    from agent1.metadata_extractor import MetadataExtractor
+
+    MetadataExtractor()


### PR DESCRIPTION
## Summary
- add integration tests that exercise the real PDFs under `data/pdfs`
- document failing UnicodeDecodeError in new TASKS.md

## Testing
- `ruff check .`
- `black .`
- `pytest -q` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_6861860a635c832cb9ab61e926a9a28f