### PR TITLE
Fix prompt encoding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,7 @@ incomplete-- to be written at a later date.
 - If `README.md` marked a feature as "under development" and you implement it, remove that notice.
 
 These instructions apply to all files in the repository.
+
+## Task Tracking
+- When you discover a repository issue that isn't necessary for completing your current task, add a concise entry to `docs/TASKS.md` so it can be addressed later.
+- Remove any item from `docs/TASKS.md` after implementing it.

--- a/agent1/openai_client.py
+++ b/agent1/openai_client.py
@@ -29,7 +29,8 @@ class OpenAIJSONCaller:
 
     def __init__(self, model: str = "gpt-4-0125-preview") -> None:
         self.model = model
-        self.prompt = PROMPT_PATH.read_text()
+        with PROMPT_PATH.open("r", encoding="utf-8") as f:
+            self.prompt = f.read()
         self.last_usage: Dict[str, int] | None = None
 
     def call(self, user_content: str, *, max_retries: int = 2) -> Dict[str, Any]:

--- a/agent2/openai_narrative.py
+++ b/agent2/openai_narrative.py
@@ -28,7 +28,8 @@ class OpenAINarrative:
 
     def __init__(self, model: str = "gpt-4-0125-preview") -> None:
         self.model = model
-        self.prompt = PROMPT_PATH.read_text()
+        with PROMPT_PATH.open("r", encoding="utf-8") as f:
+            self.prompt = f.read()
 
     @staticmethod
     def _format_input(metadata: List[Dict], snippets: List[str]) -> str:

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,8 +1,3 @@
 # Proposed Tasks
 
-The newly added integration tests in `tests/integration/test_real_pdfs.py` fail because `agent1.openai_client.OpenAIJSONCaller` reads its prompt using the platform default encoding. When the default is not UTF-8, `Path.read_text()` throws a `UnicodeDecodeError` for `prompts/agent1_prompt.txt`.
-
-## Task: enforce UTF-8 when loading prompts
-- Update `agent1/openai_client.py` to read `PROMPT_PATH` with `encoding="utf-8"`.
-- Add a similar explicit encoding in `agent2/openai_narrative.py`.
-- Verify that the integration tests pass after these changes.
+No open tasks.


### PR DESCRIPTION
## Summary
- enforce UTF-8 when reading prompts
- clear completed work from `docs/TASKS.md`
- remind contributors to track new tasks in `docs/TASKS.md`

## Testing
- `black . --check`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618a439410832c889acd0c302144ae