### PR TITLE
Clarify API key handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ incomplete-- to be written at a later date.
 2. Format and lint: `black .` and `ruff .`.
 3. Run tests: `pytest`.
 4. Ensure all checks pass before committing.
+5. Ensure your OpenAI API key is available as the `OPENAI_API_KEY` environment
+   variable. If the variable is missing, ask the user to provide the key. The
+   agent must never insert the key itself, and it cannot be stored in the
+   repository.
 
 ## Pull Request Guidelines
 - Use clear, descriptive titles.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pip install -r requirements.txt
 pip install "openai<1.0"
 ```
 
-Set your OpenAI API key in the ``OPENAI_API_KEY`` environment variable before running any pipeline steps:
+Set your OpenAI API key in the ``OPENAI_API_KEY`` environment variable before running any pipeline steps. The key must be manually added as a secret in your agent environment because it cannot be stored in the repository:
 
 ```bash
 export OPENAI_API_KEY=<your-key>

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,3 +1,3 @@
 # Proposed Tasks
 
-No open tasks.
+- Investigate why `OPENAI_API_KEY` is not detected during `test_openai_api_connection`.

--- a/tests/test_openai_api_connection.py
+++ b/tests/test_openai_api_connection.py
@@ -1,0 +1,18 @@
+import os
+
+import openai
+import pytest
+
+
+def test_openai_api_connection():
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        pytest.skip("OPENAI_API_KEY not set")
+
+    client = openai.OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "Say hello"}],
+        max_tokens=1,
+    )
+    assert response.choices[0].message.content


### PR DESCRIPTION
## Summary
- clarify the agent workflow for manually supplying the OpenAI API key

## Testing
- `black . --exclude outputs`
- `ruff check .`
- `pytest -q -rs`


------
https://chatgpt.com/codex/tasks/task_e_68618b3fde10832c8e346dae34555335