### PR TITLE
Enhance OpenAI API key detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ pip install -r requirements.txt
 pip install "openai<1.0"
 ```
 
-Set your OpenAI API key in the ``OPENAI_API_KEY`` environment variable before running any pipeline steps. The key must be manually added as a secret in your agent environment because it cannot be stored in the repository:
+Provide your OpenAI API key via the ``OPENAI_API_KEY`` environment variable or
+as a Docker secret at ``/run/secrets/openai_api_key``. The key cannot be stored
+in the repository:
 
 ```bash
 export OPENAI_API_KEY=<your-key>

--- a/agent1/openai_client.py
+++ b/agent1/openai_client.py
@@ -7,6 +7,7 @@ import orjson
 import time
 
 from utils.logger import get_logger, format_exception
+from utils.secrets import get_openai_api_key
 
 # openai is imported lazily in tests via a stub if not installed
 import openai
@@ -29,6 +30,7 @@ class OpenAIJSONCaller:
 
     def __init__(self, model: str = "gpt-4-0125-preview") -> None:
         self.model = model
+        openai.api_key = get_openai_api_key()
         with PROMPT_PATH.open("r", encoding="utf-8") as f:
             self.prompt = f.read()
         self.last_usage: Dict[str, int] | None = None

--- a/agent2/openai_narrative.py
+++ b/agent2/openai_narrative.py
@@ -6,6 +6,7 @@ import time
 import orjson
 
 from utils.logger import get_logger, format_exception
+from utils.secrets import get_openai_api_key
 
 # openai imported lazily for tests
 import openai
@@ -28,6 +29,7 @@ class OpenAINarrative:
 
     def __init__(self, model: str = "gpt-4-0125-preview") -> None:
         self.model = model
+        openai.api_key = get_openai_api_key()
         with PROMPT_PATH.open("r", encoding="utf-8") as f:
             self.prompt = f.read()
 

--- a/docs/HOW_TO_ADD_NEW_DRUG.md
+++ b/docs/HOW_TO_ADD_NEW_DRUG.md
@@ -13,7 +13,7 @@ Run the end-to-end pipeline from the repository root:
 python run_pipeline.py --pdf_dir data/new_pdfs --drug <your_drug_name>
 ```
 
-Make sure the ``OPENAI_API_KEY`` environment variable is set and that you installed ``openai<1.0``.
+Ensure the OpenAI API key is available via ``OPENAI_API_KEY`` or the secret file ``/run/secrets/openai_api_key`` and that you installed ``openai<1.0``.
 
 This command ingests the PDFs, extracts text, gathers metadata, and generates a narrative review.
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,3 +1,1 @@
 # Proposed Tasks
-
-- Investigate why `OPENAI_API_KEY` is not detected during `test_openai_api_connection`.

--- a/tests/agent2/test_openai_narrative.py
+++ b/tests/agent2/test_openai_narrative.py
@@ -28,6 +28,12 @@ fake_chat = FakeChatCompletion()
 fake_openai.ChatCompletion = fake_chat
 sys.modules["openai"] = fake_openai
 
+
+@pytest.fixture(autouse=True)
+def fake_openai_key(monkeypatch):
+    monkeypatch.setattr("agent2.openai_narrative.get_openai_api_key", lambda: "key")
+
+
 from agent2.openai_narrative import OpenAINarrative  # noqa: E402
 
 

--- a/tests/integration/test_real_pdfs.py
+++ b/tests/integration/test_real_pdfs.py
@@ -6,6 +6,11 @@ from ingest.collector import ingest_pdf
 from extract.pdf_to_text import pdf_to_text
 
 
+@pytest.fixture(autouse=True)
+def fake_openai_key(monkeypatch):
+    monkeypatch.setattr("agent1.openai_client.get_openai_api_key", lambda: "key")
+
+
 class FakeClient:
     def __init__(self, response):
         self.response = response

--- a/tests/test_openai_api_connection.py
+++ b/tests/test_openai_api_connection.py
@@ -1,13 +1,13 @@
-import os
-
 import openai
 import pytest
+from utils.secrets import get_openai_api_key
 
 
 def test_openai_api_connection():
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        pytest.skip("OPENAI_API_KEY not set")
+    try:
+        api_key = get_openai_api_key()
+    except RuntimeError:
+        pytest.skip("OPENAI_API_KEY not found")
 
     client = openai.OpenAI(api_key=api_key)
     response = client.chat.completions.create(

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,8 +1,8 @@
 import sys
 import types
+import pytest
 
 import orjson
-import pytest
 
 # Create a fake openai module
 fake_openai = types.ModuleType("openai")
@@ -27,6 +27,12 @@ class FakeChatCompletion:
 fake_chat = FakeChatCompletion()
 fake_openai.ChatCompletion = fake_chat
 sys.modules["openai"] = fake_openai
+
+
+@pytest.fixture(autouse=True)
+def fake_openai_key(monkeypatch):
+    monkeypatch.setattr("agent1.openai_client.get_openai_api_key", lambda: "key")
+
 
 from agent1.openai_client import OpenAIJSONCaller  # noqa: E402
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,9 +1,16 @@
 from pathlib import Path
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
+import pytest
 
 import pipeline
 from schemas.metadata import PaperMetadata
+
+
+@pytest.fixture(autouse=True)
+def fake_openai_key(monkeypatch):
+    monkeypatch.setattr("agent1.openai_client.get_openai_api_key", lambda: "key")
+    monkeypatch.setattr("agent2.openai_narrative.get_openai_api_key", lambda: "key")
 
 
 def create_pdf(path: Path) -> None:

--- a/utils/secrets.py
+++ b/utils/secrets.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+
+
+def get_openai_api_key() -> str:
+    """Return the OpenAI API key from env or secret file.
+
+    The function first checks the ``OPENAI_API_KEY`` environment variable. If not
+    set, it looks for a file specified by ``OPENAI_API_KEY_FILE`` or the Docker
+    secret ``/run/secrets/openai_api_key``. If the key cannot be found, a
+    ``RuntimeError`` is raised.
+    """
+
+    key = os.getenv("OPENAI_API_KEY")
+    if key:
+        return key.strip()
+
+    file_env = os.getenv("OPENAI_API_KEY_FILE")
+    paths = [Path(file_env)] if file_env else []
+    paths.append(Path("/run/secrets/openai_api_key"))
+
+    for path in paths:
+        if path.is_file():
+            return path.read_text(encoding="utf-8").strip()
+
+    raise RuntimeError(
+        "OPENAI_API_KEY not found as environment variable or secret file"
+    )


### PR DESCRIPTION
## Summary
- add helper `get_openai_api_key` that searches env vars and `/run/secrets/openai_api_key`
- load the API key in `OpenAIJSONCaller` and `OpenAINarrative`
- update docs to describe secret-based key loading
- adjust tests to patch the new helper so unit tests remain isolated

## Testing
- `ruff check . --fix`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618fa0966c832c8d0675c44f046755