### PR TITLE
Fix docs to match openai version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,12 @@ python3 -m venv venv
 source venv/bin/activate
 ```
 
-Install dependencies:
+Install dependencies from the provided requirements file:
 
 ```bash
 pip install -r requirements.txt
-# The pipeline relies on the pre-1.0 OpenAI client
-pip install "openai<1.0"
 ```
+This installs the pinned OpenAI client and all other packages needed for the pipeline.
 
 Provide your OpenAI API key via the ``OPENAI_API_KEY`` environment variable or
 as a Docker secret at ``/run/secrets/openai_api_key``. The key cannot be stored

--- a/docs/HOW_TO_ADD_NEW_DRUG.md
+++ b/docs/HOW_TO_ADD_NEW_DRUG.md
@@ -13,7 +13,7 @@ Run the end-to-end pipeline from the repository root:
 python run_pipeline.py --pdf_dir data/new_pdfs --drug <your_drug_name>
 ```
 
-Ensure the OpenAI API key is available via ``OPENAI_API_KEY`` or the secret file ``/run/secrets/openai_api_key`` and that you installed ``openai<1.0``.
+Ensure the OpenAI API key is available via ``OPENAI_API_KEY`` or the secret file ``/run/secrets/openai_api_key`` and that you've installed the dependencies from ``requirements.txt``.
 
 This command ingests the PDFs, extracts text, gathers metadata, and generates a narrative review.
 


### PR DESCRIPTION
## Summary
- remove outdated install notes about `openai<1.0` in README
- update the new drug guide to reference `requirements.txt`

## Testing
- `black .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68619505e2c4832cb11fd39c8982b842