### PR TITLE
Add tests for OpenAI key retrieval

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,6 +1,5 @@
 # Proposed Tasks
 
-- Add unit tests for `utils.secrets.get_openai_api_key` covering env var, file, and missing key scenarios.
 - Add unit tests for `ingest.list_pdfs` to verify it lists PDF filenames correctly.
 - Add unit tests for `pipeline.generate_narrative` and `pipeline.timed_step` with mocks to avoid API calls.
 - Add unit tests for `aggregate._log_error` and `_backup_master` helper functions.

--- a/tests/test_utils_secrets.py
+++ b/tests/test_utils_secrets.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import pytest
+
+from utils.secrets import get_openai_api_key
+
+
+def test_env_var_priority(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    file = tmp_path / "key.txt"
+    file.write_text("file-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    monkeypatch.setenv("OPENAI_API_KEY_FILE", str(file))
+    assert get_openai_api_key() == "env-key"
+
+
+def test_file_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    key_file = tmp_path / "key.txt"
+    key_file.write_text("file-key")
+    monkeypatch.setenv("OPENAI_API_KEY_FILE", str(key_file))
+    assert get_openai_api_key() == "file-key"
+
+
+def test_missing_key(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    missing = tmp_path / "does_not_exist"
+    monkeypatch.setenv("OPENAI_API_KEY_FILE", str(missing))
+    with pytest.raises(RuntimeError):
+        get_openai_api_key()


### PR DESCRIPTION
## Summary
- add coverage for `utils.secrets.get_openai_api_key`
- remove completed TODO from `docs/TASKS.md`

## Testing
- `ruff check tests/test_utils_secrets.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861988bee9c832c838a454496f9355f