### PR TITLE
Fix integration tests for OpenAI v1

### DIFF
--- a/agent1/openai_client.py
+++ b/agent1/openai_client.py
@@ -10,16 +10,22 @@ from utils.logger import get_logger, format_exception
 from utils.secrets import get_openai_api_key
 
 # openai is imported lazily in tests via a stub if not installed
+import openai
 from openai import OpenAI
 
-client = OpenAI(api_key=get_openai_api_key())
+_client: OpenAI | None = None
 
-AuthError = getattr(openai, "error", type("error", (), {})).__dict__.get(
-    "AuthenticationError", Exception
-)
-RateLimitError = getattr(openai, "error", type("error", (), {})).__dict__.get(
-    "RateLimitError", Exception
-)
+
+def get_client() -> OpenAI:
+    """Return a cached OpenAI client."""
+    global _client
+    if _client is None:
+        _client = OpenAI(api_key=get_openai_api_key())
+    return _client
+
+
+AuthError = getattr(openai, "AuthenticationError", Exception)
+RateLimitError = getattr(openai, "RateLimitError", Exception)
 
 PROMPT_PATH = Path(__file__).resolve().parents[1] / "prompts" / "agent1_prompt.txt"
 
@@ -43,12 +49,15 @@ class OpenAIJSONCaller:
             {"role": "user", "content": user_content},
         ]
         delay = 1.0
+        client = get_client()
         for attempt in range(max_retries + 1):
             start_time = time.time()
             try:
-                response = client.chat.completions.create(model=self.model,
-                messages=messages,
-                response_format={"type": "json_object"})
+                response = client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,
+                    response_format={"type": "json_object"},
+                )
             except AuthError as exc:  # pragma: no cover - auth errors
                 duration = time.time() - start_time
                 logger.error(

--- a/tests/agent2/test_openai_narrative.py
+++ b/tests/agent2/test_openai_narrative.py
@@ -6,9 +6,12 @@ import pytest
 
 # Setup fake openai module before import
 fake_openai = types.ModuleType("openai")
-fake_openai.error = types.SimpleNamespace()
-fake_openai.error.AuthenticationError = type("AuthError", (Exception,), {})
-fake_openai.error.RateLimitError = type("RateLimitError", (Exception,), {})
+fake_openai.AuthenticationError = type("AuthError", (Exception,), {})
+fake_openai.RateLimitError = type("RateLimitError", (Exception,), {})
+fake_openai.error = types.SimpleNamespace(
+    AuthenticationError=fake_openai.AuthenticationError,
+    RateLimitError=fake_openai.RateLimitError,
+)
 
 
 class FakeChatCompletion:
@@ -21,11 +24,28 @@ class FakeChatCompletion:
         resp = self.responses.pop(0)
         if isinstance(resp, Exception):
             raise resp
+        if isinstance(resp, dict):
+            usage = resp.get("usage", {})
+
+            def to_ns(obj):
+                if isinstance(obj, dict):
+                    return types.SimpleNamespace(
+                        **{k: to_ns(v) for k, v in obj.items()}
+                    )
+                if isinstance(obj, list):
+                    return [to_ns(x) for x in obj]
+                return obj
+
+            ns = to_ns({k: v for k, v in resp.items() if k != "usage"})
+            ns.usage = usage
+            return ns
         return resp
 
 
 fake_chat = FakeChatCompletion()
+fake_client = types.SimpleNamespace(chat=types.SimpleNamespace(completions=fake_chat))
 fake_openai.ChatCompletion = fake_chat
+fake_openai.OpenAI = lambda api_key=None: fake_client
 sys.modules["openai"] = fake_openai
 
 


### PR DESCRIPTION
## Summary
- lazily initialize OpenAI client to avoid requiring API key at import
- add helper to retrieve cached OpenAI client
- update unit tests to work with OpenAI v1 response objects

## Testing
- `black agent1/openai_client.py agent2/openai_narrative.py tests/test_openai_client.py tests/agent2/test_openai_narrative.py`
- `ruff check agent1/openai_client.py agent2/openai_narrative.py tests/test_openai_client.py tests/agent2/test_openai_narrative.py`
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619e03d6c4832cb60d56721647ec41