### PR TITLE
Fix OpenAI error imports in metadata client

### DIFF
--- a/agent1/openai_client.py
+++ b/agent1/openai_client.py
@@ -24,8 +24,13 @@ def get_client() -> OpenAI:
     return _client
 
 
-AuthError = getattr(openai, "AuthenticationError", Exception)
-RateLimitError = getattr(openai, "RateLimitError", Exception)
+try:  # OpenAI SDK v1.x
+    AuthError = openai.AuthenticationError
+    RateLimitError = openai.RateLimitError
+except AttributeError:  # pragma: no cover - fallback for older SDKs
+    errors = getattr(openai, "error", type("error", (), {}))
+    AuthError = getattr(errors, "AuthenticationError", Exception)
+    RateLimitError = getattr(errors, "RateLimitError", Exception)
 
 PROMPT_PATH = Path(__file__).resolve().parents[1] / "prompts" / "agent1_prompt.txt"
 


### PR DESCRIPTION
## Summary
- update `agent1/openai_client.py` to import error classes correctly
- add fallback compatibility for older OpenAI packages

## Testing
- `black agent1/openai_client.py`
- `ruff check agent1/openai_client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861a0b6f1dc832c9f6bbce87c4ed3f1