### PR TITLE
Add live OpenAI JSON caller test

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ in the repository:
 export OPENAI_API_KEY=<your-key>
 ```
 
+## Testing
+Run `pytest` to execute the test suite. Any test that requires the OpenAI API
+will use your configured key and is skipped automatically if the key is absent.
+
 ## Usage
 1. Place your academic PDFs in `data/pdfs/`.
 2. Run ingestion and text extraction **for each PDF**:

--- a/tests/test_openai_json_caller_live.py
+++ b/tests/test_openai_json_caller_live.py
@@ -1,0 +1,33 @@
+import pytest
+from agent1.openai_client import OpenAIJSONCaller
+from utils.secrets import get_openai_api_key
+from schemas.metadata import PaperMetadata
+
+
+def test_openai_json_caller_live():
+    try:
+        get_openai_api_key()
+    except RuntimeError:
+        pytest.skip("OPENAI_API_KEY not found")
+
+    caller = OpenAIJSONCaller(model="gpt-3.5-turbo")
+    snippet = (
+        "Title: Example Study\n"
+        "Authors: Doe et al. (2024)\n"
+        "DOI: 10.1234/example\n"
+        "Published: 2024-01-01\n"
+        "Data Source: INTERVAL"
+    )
+    result = caller.call(snippet)
+    PaperMetadata.model_validate(result)
+    assert set(result) >= {
+        "title",
+        "authors",
+        "doi",
+        "pub_date",
+        "data_sources",
+        "omics_modalities",
+        "targets",
+        "p_threshold",
+        "ld_r2",
+    }


### PR DESCRIPTION
## Summary
- add `test_openai_json_caller_live` for real OpenAI API usage
- mention new testing section in `README`

## Testing
- `black . --quiet`
- `ruff check .`
- `pytest -q` *(fails: 0)*

------
https://chatgpt.com/codex/tasks/task_e_6861a0e45280832cae472d2d22b6c1e4