### PR TITLE
Fix logging for OpenAI usage objects

### DIFF
--- a/agent1/metadata_extractor.py
+++ b/agent1/metadata_extractor.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError
 
 from utils.logger import get_logger, format_exception
 
-from agent1.openai_client import OpenAIJSONCaller
+from agent1.openai_client import OpenAIJSONCaller, _usage_get
 from schemas.metadata import PaperMetadata
 
 META_DIR = Path(__file__).resolve().parents[1] / "data" / "meta"
@@ -74,9 +74,9 @@ class MetadataExtractor:
                 if usage:
                     logger.info(
                         "Tokens used: prompt=%s completion=%s total=%s",
-                        usage.get("prompt_tokens"),
-                        usage.get("completion_tokens"),
-                        usage.get("total_tokens"),
+                        _usage_get(usage, "prompt_tokens"),
+                        _usage_get(usage, "completion_tokens"),
+                        _usage_get(usage, "total_tokens"),
                     )
                 if attempt == 1:
                     return None
@@ -87,9 +87,9 @@ class MetadataExtractor:
                 if usage:
                     logger.info(
                         "Tokens used: prompt=%s completion=%s total=%s",
-                        usage.get("prompt_tokens"),
-                        usage.get("completion_tokens"),
-                        usage.get("total_tokens"),
+                        _usage_get(usage, "prompt_tokens"),
+                        _usage_get(usage, "completion_tokens"),
+                        _usage_get(usage, "total_tokens"),
                     )
                 self._save(metadata, src_path, text)
                 return metadata

--- a/agent1/openai_client.py
+++ b/agent1/openai_client.py
@@ -38,6 +38,15 @@ PROMPT_PATH = Path(__file__).resolve().parents[1] / "prompts" / "agent1_prompt.t
 logger = get_logger(__name__)
 
 
+def _usage_get(usage: Any, key: str) -> Any:
+    """Return token counts from either a dict or OpenAI usage object."""
+    if usage is None:
+        return None
+    if isinstance(usage, dict):
+        return usage.get(key)
+    return getattr(usage, key, None)
+
+
 class OpenAIJSONCaller:
     """Helper for calling OpenAI's chat completion API in JSON mode."""
 
@@ -104,9 +113,9 @@ class OpenAIJSONCaller:
             if self.last_usage:
                 logger.info(
                     "Tokens used: prompt=%s completion=%s total=%s",
-                    self.last_usage.get("prompt_tokens"),
-                    self.last_usage.get("completion_tokens"),
-                    self.last_usage.get("total_tokens"),
+                    _usage_get(self.last_usage, "prompt_tokens"),
+                    _usage_get(self.last_usage, "completion_tokens"),
+                    _usage_get(self.last_usage, "total_tokens"),
                 )
             content = response.choices[0].message.content
             try:

--- a/agent2/openai_narrative.py
+++ b/agent2/openai_narrative.py
@@ -32,6 +32,15 @@ PROMPT_PATH = Path(__file__).resolve().parents[1] / "prompts" / "agent2_system.t
 logger = get_logger(__name__)
 
 
+def _usage_get(usage, key):
+    """Return token counts from a dict or OpenAI usage object."""
+    if usage is None:
+        return None
+    if isinstance(usage, dict):
+        return usage.get(key)
+    return getattr(usage, key, None)
+
+
 class OpenAINarrative:
     """Helper for generating narrative reviews using OpenAI."""
 
@@ -104,9 +113,9 @@ class OpenAINarrative:
             if usage:
                 logger.info(
                     "Tokens used: prompt=%s completion=%s total=%s",
-                    usage.get("prompt_tokens"),
-                    usage.get("completion_tokens"),
-                    usage.get("total_tokens"),
+                    _usage_get(usage, "prompt_tokens"),
+                    _usage_get(usage, "completion_tokens"),
+                    _usage_get(usage, "total_tokens"),
                 )
             content = response.choices[0].message.content
             logger.info("Narrative generation succeeded")


### PR DESCRIPTION
## Summary
- handle CompletionUsage objects from OpenAI SDK
- report token counts correctly for both dict and object forms

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a3427180832c8901b8fb8c1d3284