### PR TITLE
Pass drug name to metadata extractor

### DIFF
--- a/agent1/metadata_extractor.py
+++ b/agent1/metadata_extractor.py
@@ -55,7 +55,13 @@ class MetadataExtractor:
         out_path.write_bytes(orjson.dumps(metadata.model_dump()))
         return out_path
 
-    def extract(self, text_or_path: Union[str, Path]) -> Optional[PaperMetadata]:
+    def extract(
+        self, text_or_path: Union[str, Path], drug_name: str | None = None
+    ) -> Optional[PaperMetadata]:
+        """Extract metadata from ``text_or_path``.
+
+        ``drug_name`` is accepted for future use but currently ignored.
+        """
         text, src_path = self._load_text(text_or_path)
         for attempt in range(2):
             start = time.time()

--- a/pipeline.py
+++ b/pipeline.py
@@ -39,12 +39,12 @@ def ingest_pdfs(pdf_dir: str) -> List[Path]:
     return paths
 
 
-def extract_metadata_from_text() -> List[Path]:
-    """Run Agent 1 on all text files in ``TEXT_DIR``."""
+def extract_metadata_from_text(drug_name: str) -> List[Path]:
+    """Run Agent 1 on all text files in ``TEXT_DIR`` using ``drug_name``."""
     extractor = MetadataExtractor()
     results = []
     for text_path in sorted(TEXT_DIR.glob("*.json")):
-        meta = extractor.extract(text_path)
+        meta = extractor.extract(text_path, drug_name)
         if meta is not None:
             results.append(text_path)
     return results
@@ -83,7 +83,9 @@ def run_pipeline(pdf_dir: str, drug_name: str) -> None:
     """Execute the full data processing pipeline."""
     metrics: Dict[str, StepMetrics] = {}
     timed_step(lambda: ingest_pdfs(pdf_dir), "Ingestion", metrics)
-    timed_step(extract_metadata_from_text, "Metadata Extraction", metrics)
+    timed_step(
+        lambda: extract_metadata_from_text(drug_name), "Metadata Extraction", metrics
+    )
     timed_step(aggregate.aggregate_metadata, "Aggregation", metrics)
     timed_step(lambda: generate_narrative(drug_name), "Narrative Generation", metrics)
     logger.info("-- Performance Summary --")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -55,7 +55,7 @@ def test_run_pipeline(monkeypatch, tmp_path):
     monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
     monkeypatch.setattr(
         "agent1.metadata_extractor.MetadataExtractor.extract",
-        lambda self, _path: PaperMetadata(**valid_metadata()),
+        lambda self, _path, _drug=None: PaperMetadata(**valid_metadata()),
     )
     monkeypatch.setattr("aggregate.META_DIR", tmp_path / "meta")
     monkeypatch.setattr("aggregate.MASTER_PATH", tmp_path / "master.json")

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -20,7 +20,9 @@ class FakeExtractor:
     def __init__(self) -> None:
         self.calls: list[Path] = []
 
-    def extract(self, text_path: Path) -> PaperMetadata | None:
+    def extract(
+        self, text_path: Path, _drug: str | None = None
+    ) -> PaperMetadata | None:
         self.calls.append(text_path)
         return PaperMetadata(title="T", doi="10.1/test")
 


### PR DESCRIPTION
## Summary
- extend `MetadataExtractor.extract` to accept an optional `drug_name`
- forward drug name through the pipeline so metadata extraction receives it
- update tests for the new method signature

## Testing
- `black .`
- `ruff .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d3e880b0832c8737691c35bee3e4