### PR TITLE
Add optional drug name to metadata extraction

### DIFF
--- a/agent1/metadata_extractor.py
+++ b/agent1/metadata_extractor.py
@@ -55,13 +55,17 @@ class MetadataExtractor:
         out_path.write_bytes(orjson.dumps(metadata.model_dump()))
         return out_path
 
-    def extract(self, text_or_path: Union[str, Path]) -> Optional[PaperMetadata]:
+    def extract(
+        self, text_or_path: Union[str, Path], drug_name: Optional[str] = None
+    ) -> Optional[PaperMetadata]:
         text, src_path = self._load_text(text_or_path)
         for attempt in range(2):
             start = time.time()
             try:
                 result = self.client.call(text)
                 metadata = PaperMetadata.model_validate(result)
+                if drug_name is not None:
+                    metadata.targets = [drug_name]
             except (ValidationError, Exception) as exc:
                 duration = time.time() - start
                 logger.error(

--- a/tests/agent1/test_agent1_metadata.py
+++ b/tests/agent1/test_agent1_metadata.py
@@ -42,7 +42,7 @@ def test_retry_logic(monkeypatch, tmp_path):
     text_path = create_text_file(tmp_path)
     client = FakeClient([{"title": 1}, {"title": "T"}])
     extractor = MetadataExtractor(client=client)
-    result = extractor.extract(text_path)
+    result = extractor.extract(text_path, "Drug")
     assert result is not None
     assert client.calls == 2
 

--- a/tests/integration/test_real_pdfs.py
+++ b/tests/integration/test_real_pdfs.py
@@ -35,7 +35,7 @@ def test_full_extraction_real_file(
     from agent1.metadata_extractor import MetadataExtractor
 
     extractor = MetadataExtractor()
-    meta = extractor.extract(tmp_path / "text" / f"{pdf_path.stem}.json")
+    meta = extractor.extract(tmp_path / "text" / f"{pdf_path.stem}.json", "Drug")
     assert meta is not None
     PaperMetadata.model_validate(meta.model_dump())
 

--- a/tests/test_metadata_extractor.py
+++ b/tests/test_metadata_extractor.py
@@ -52,7 +52,7 @@ def test_extract_success(tmp_path, monkeypatch):
     monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
     client = FakeClient([valid_data()])
     extractor = MetadataExtractor(client=client)
-    result = extractor.extract(text_path)
+    result = extractor.extract(text_path, "Drug")
     assert result is not None
     out_file = tmp_path / "meta" / "10.1_abc.json"
     assert out_file.exists()
@@ -66,7 +66,7 @@ def test_extract_retry(tmp_path, monkeypatch):
     monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
     client = FakeClient([{"title": 1}, valid_data()])
     extractor = MetadataExtractor(client=client)
-    result = extractor.extract(text_path)
+    result = extractor.extract(text_path, "Drug")
     assert result is not None
     assert client.calls == 2
 
@@ -78,7 +78,7 @@ def test_extract_fail(tmp_path, monkeypatch):
     monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
     client = FakeClient([{"title": 1}, {"title": 2}])
     extractor = MetadataExtractor(client=client)
-    result = extractor.extract(text_path)
+    result = extractor.extract(text_path, "Drug")
     assert result is None
     assert client.calls == 2
     assert not list((tmp_path / "meta").glob("*.json"))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -55,7 +55,7 @@ def test_run_pipeline(monkeypatch, tmp_path):
     monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
     monkeypatch.setattr(
         "agent1.metadata_extractor.MetadataExtractor.extract",
-        lambda self, _path: PaperMetadata(**valid_metadata()),
+        lambda self, _path, drug_name=None: PaperMetadata(**valid_metadata()),
     )
     monkeypatch.setattr("aggregate.META_DIR", tmp_path / "meta")
     monkeypatch.setattr("aggregate.MASTER_PATH", tmp_path / "master.json")

--- a/tests/test_z_pipeline.py
+++ b/tests/test_z_pipeline.py
@@ -81,7 +81,7 @@ def test_full_pipeline(tmp_path, monkeypatch):
     monkeypatch.setattr("agent1.metadata_extractor.META_DIR", meta_dir)
     client = FakeClient(valid_metadata())
     extractor = MetadataExtractor(client=client)
-    meta = extractor.extract(text_path)
+    meta = extractor.extract(text_path, "Drug")
     assert meta is not None
     out_file = meta_dir / "10.1_test.json"
     assert out_file.exists()


### PR DESCRIPTION
## Summary
- allow `MetadataExtractor.extract` to take an optional `drug_name`
- store `drug_name` into the metadata targets list when provided
- update unit tests to supply the new argument

## Testing
- `pip install -r requirements.txt`
- `black .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862d3e898f8832cb0437f1c0dd19615