### PR TITLE
Add live OpenAI integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ export OPENAI_API_KEY=<your-key>
 ## Testing
 Run `pytest` to execute the test suite. Any test that requires the OpenAI API
 will use your configured key and is skipped automatically if the key is absent.
+Live integration tests that exercise the entire pipeline are located under
+`tests/integration/` and in `tests/agent2/test_openai_narrative_live.py`.
 
 ## Usage
 1. Place your academic PDFs in `data/pdfs/`.

--- a/tests/agent2/test_openai_narrative_live.py
+++ b/tests/agent2/test_openai_narrative_live.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from agent2.openai_narrative import OpenAINarrative
+from utils.secrets import get_openai_api_key
+
+
+def test_openai_narrative_live():
+    try:
+        get_openai_api_key()
+    except RuntimeError:
+        pytest.skip("OPENAI_API_KEY not found")
+
+    narrative = OpenAINarrative(model="gpt-3.5-turbo")
+    metadata = [{"title": "Test", "doi": "10.1234/test"}]
+    snippet = ["Example snippet from the paper."]
+    result = narrative.generate(metadata, snippet)
+    assert isinstance(result, str) and result.strip()


### PR DESCRIPTION
## Summary
- add `test_openai_narrative_live` to exercise `OpenAINarrative` against real API
- document integration tests in README

## Testing
- `ruff check tests/agent2/test_openai_narrative_live.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862eec99ad4832c8ffbc3a3f13c4b72