### PR TITLE
Add teardown hooks to reset OpenAI stubs

### DIFF
--- a/tests/agent2/test_openai_narrative.py
+++ b/tests/agent2/test_openai_narrative.py
@@ -49,6 +49,12 @@ fake_openai.OpenAI = lambda api_key=None: fake_client
 sys.modules["openai"] = fake_openai
 
 
+def teardown_module(module):
+    """Restore the real OpenAI module after tests."""
+    for mod in ("agent2.openai_narrative", "openai"):
+        sys.modules.pop(mod, None)
+
+
 @pytest.fixture(autouse=True)
 def fake_openai_key(monkeypatch):
     monkeypatch.setattr("agent2.openai_narrative.get_openai_api_key", lambda: "key")

--- a/tests/agent2/test_synthesiser_cli.py
+++ b/tests/agent2/test_synthesiser_cli.py
@@ -10,6 +10,13 @@ import orjson
 fake_openai = types.ModuleType("openai")
 sys.modules["openai"] = fake_openai
 
+
+def teardown_module(module):
+    """Restore the real OpenAI module after tests."""
+    for mod in ("agent2.synthesiser", "openai"):
+        sys.modules.pop(mod, None)
+
+
 import agent2.synthesiser as synthesiser  # noqa: E402
 
 

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -49,6 +49,12 @@ fake_openai.OpenAI = lambda api_key=None: fake_client
 sys.modules["openai"] = fake_openai
 
 
+def teardown_module(module):
+    """Restore the real OpenAI module after tests."""
+    for mod in ("agent1.openai_client", "openai"):
+        sys.modules.pop(mod, None)
+
+
 @pytest.fixture(autouse=True)
 def fake_openai_key(monkeypatch):
     monkeypatch.setattr("agent1.openai_client.get_openai_api_key", lambda: "key")


### PR DESCRIPTION
## Summary
- clean up fake OpenAI modules at the end of unit tests

## Testing
- `pytest -q` *(fails: IndexError pop from empty list)*

------
https://chatgpt.com/codex/tasks/task_e_6862fc9dd0d4832c9f49cd48ddc534be