### PR TITLE
Add model selection option to pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Below is a brief description of the main scripts and where their outputs are wri
   directory.
 - `pipeline.py` and `run_pipeline.py` orchestrate the entire workflow—ingestion,
   metadata extraction, aggregation and narrative generation—when run from the
-  command line.
+  command line. Both accept an optional `--model` argument to override the
+  default OpenAI model used for metadata extraction and narrative generation.
 - `run_smoke_test.py` ingests a single PDF and prints the first few hundred
   characters from each page as a quick sanity check.
 - `utils/data_wipe.py` deletes generated data and logs. Pass `--with-pdfs` to
@@ -135,7 +136,7 @@ python agent2/synthesiser.py --drug <drug-name>
 6. Run the entire pipeline in one step using the CLI script:
 
 ```bash
-python run_pipeline.py --pdf_dir data/pdfs --drug <drug-name>
+python run_pipeline.py --pdf_dir data/pdfs --drug <drug-name> --model <model-name>
 
 ```
 

--- a/agent1/metadata_extractor.py
+++ b/agent1/metadata_extractor.py
@@ -22,8 +22,13 @@ logger = get_logger(__name__)
 class MetadataExtractor:
     """Extract metadata from text using OpenAI and validate against schema."""
 
-    def __init__(self, client: Optional[OpenAIJSONCaller] = None) -> None:
-        self.client = client or OpenAIJSONCaller()
+    def __init__(
+        self,
+        client: Optional[OpenAIJSONCaller] = None,
+        *,
+        model: str = "gpt-4-0125-preview",
+    ) -> None:
+        self.client = client or OpenAIJSONCaller(model=model)
         META_DIR.mkdir(parents=True, exist_ok=True)
 
     @staticmethod

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -10,8 +10,9 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run MR literature pipeline.")
     parser.add_argument("--pdf_dir", required=True, help="Directory containing PDFs")
     parser.add_argument("--drug", required=True, help="Name of the drug for review")
+    parser.add_argument("--model", help="OpenAI model name")
     args = parser.parse_args(argv)
-    pipeline.run_pipeline(args.pdf_dir, args.drug)
+    pipeline.run_pipeline(args.pdf_dir, args.drug, args.model)
     return 0
 
 

--- a/tests/agent1/test_agent1_metadata.py
+++ b/tests/agent1/test_agent1_metadata.py
@@ -70,7 +70,7 @@ def test_cli_end_to_end(monkeypatch, tmp_path):
     result = {"title": "T", "doi": "10.1/x"}
     fake_client = FakeClient([result])
     monkeypatch.setattr(
-        "agent1.metadata_extractor.OpenAIJSONCaller", lambda: fake_client
+        "agent1.metadata_extractor.OpenAIJSONCaller", lambda *a, **k: fake_client
     )
     monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
     monkeypatch.setattr("extract.pdf_to_text.DATA_DIR", tmp_path / "text")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -64,7 +64,7 @@ def test_run_pipeline(monkeypatch, tmp_path):
     monkeypatch.setattr("pipeline.OUTPUT_DIR", tmp_path / "out")
 
     fake = FakeNarrative()
-    monkeypatch.setattr("pipeline.OpenAINarrative", lambda: fake)
+    monkeypatch.setattr("pipeline.OpenAINarrative", lambda *a, **k: fake)
 
     pipeline.run_pipeline(str(pdf_dir), "test")
 

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -45,11 +45,13 @@ def test_full_pipeline_cli(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("pipeline.OUTPUT_DIR", tmp_path / "outputs")
 
     extractor = FakeExtractor(tmp_path / "meta")
-    monkeypatch.setattr("pipeline.MetadataExtractor", lambda: extractor)
+    monkeypatch.setattr("pipeline.MetadataExtractor", lambda *a, **k: extractor)
     narrative = FakeNarrative()
-    monkeypatch.setattr("pipeline.OpenAINarrative", lambda: narrative)
+    monkeypatch.setattr("pipeline.OpenAINarrative", lambda *a, **k: narrative)
 
-    code = run_pipeline.main(["--pdf_dir", str(pdf_dir), "--drug", "TestDrug"])
+    code = run_pipeline.main(
+        ["--pdf_dir", str(pdf_dir), "--drug", "TestDrug", "--model", "m"]
+    )
     assert code == 0
 
     master_path = tmp_path / "master.json"

--- a/tests/test_run_pipeline_cli.py
+++ b/tests/test_run_pipeline_cli.py
@@ -6,12 +6,22 @@ import run_pipeline
 def test_main_invokes_pipeline(monkeypatch):
     calls = {}
 
-    def fake_run(pdf_dir: str, drug: str) -> None:
+    def fake_run(pdf_dir: str, drug: str, model: str | None) -> None:
         calls["pdf_dir"] = pdf_dir
         calls["drug"] = drug
+        calls["model"] = model
 
     monkeypatch.setattr("pipeline.run_pipeline", fake_run)
 
-    code = run_pipeline.main(["--pdf_dir", "data/pdfs", "--drug", "rapa"])
+    code = run_pipeline.main(
+        [
+            "--pdf_dir",
+            "data/pdfs",
+            "--drug",
+            "rapa",
+            "--model",
+            "m",
+        ]
+    )
     assert code == 0
-    assert calls == {"pdf_dir": "data/pdfs", "drug": "rapa"}
+    assert calls == {"pdf_dir": "data/pdfs", "drug": "rapa", "model": "m"}


### PR DESCRIPTION
## Summary
- allow setting the OpenAI model when running the pipeline
- pass model name through run_pipeline and CLI
- update metadata extractor to accept a model argument
- adapt tests for new parameter
- document `--model` option in README

## Testing
- `black . --check`
- `ruff check .`
- `pytest -q` *(fails: openai API calls require network access)*

------
https://chatgpt.com/codex/tasks/task_e_6863125a36e8832cafbf082789fe58b7