### PR TITLE
Add FAISS text embedding index

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This project automates the extraction and synthesis of structured information fr
 - **Metadata Extraction (Agent 1)**: Uses the OpenAI API to pull key metadata fields into JSON.
 - **Data Aggregation**: Collates individual metadata JSON files into a master dataset.
 - **Text Retrieval Helper**: Fetches keyword-based snippets from stored PDF text files for downstream RAG tasks.
+- **Embedding Indexing**: Builds a FAISS vector store from extracted text for semantic snippet retrieval.
+- **Embedding-based Retrieval**: Searches the FAISS index for semantically similar text chunks.
 - **Narrative Review Generation (Agent 2)**: Generates peer-review style summaries using `agent2/openai_narrative.py`.
 
 ## Script Overview

--- a/agent2/vector_index.py
+++ b/agent2/vector_index.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict, Any
+import pickle
+
+import orjson
+from sklearn.feature_extraction.text import TfidfVectorizer
+import faiss
+
+
+def _safe_name(doi: str) -> str:
+    return doi.replace("/", "_").replace(":", "_")
+
+
+def _chunk_text(text: str, size: int = 200) -> List[str]:
+    words = text.split()
+    return [" ".join(words[i : i + size]) for i in range(0, len(words), size)]
+
+
+def build_vector_index(text_json_paths: List[Path], index_path: Path) -> None:
+    """Build a FAISS embedding index from extracted text JSON files."""
+    chunks: List[Dict[str, Any]] = []
+    for path in text_json_paths:
+        data = orjson.loads(path.read_bytes())
+        pages = data.get("pages", [])
+        text = " ".join(p.get("text", "") for p in pages)
+        for idx, chunk in enumerate(_chunk_text(text)):
+            chunks.append(
+                {
+                    "text": chunk,
+                    "chunk_id": f"{path.stem}_{idx}",
+                    "doi": path.stem,
+                }
+            )
+
+    if not chunks:
+        return
+
+    corpus = [c["text"] for c in chunks]
+    vectorizer = TfidfVectorizer(stop_words="english")
+    matrix = vectorizer.fit_transform(corpus)
+    embeddings = matrix.toarray().astype("float32")
+    faiss.normalize_L2(embeddings)
+
+    index = faiss.IndexFlatIP(embeddings.shape[1])
+    index.add(embeddings)
+
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    faiss.write_index(index, str(index_path))
+    index_path.with_suffix(".meta.json").write_bytes(orjson.dumps(chunks))
+    with open(index_path.with_suffix(".vec"), "wb") as f:
+        pickle.dump(vectorizer, f)
+
+
+def query_index(
+    doi: str, query: str, k: int = 5, index_path: Path | None = None
+) -> List[Dict[str, Any]]:
+    """Retrieve top-k semantically relevant text snippets from a single document identified by DOI."""
+    if index_path is None:
+        raise ValueError("index_path is required")
+    if not index_path.exists():
+        raise FileNotFoundError(index_path)
+
+    index = faiss.read_index(str(index_path))
+    chunks = orjson.loads(index_path.with_suffix(".meta.json").read_bytes())
+    with open(index_path.with_suffix(".vec"), "rb") as f:
+        vectorizer: TfidfVectorizer = pickle.load(f)
+
+    query_vec = vectorizer.transform([query]).toarray().astype("float32")
+    faiss.normalize_L2(query_vec)
+    scores, indices = index.search(query_vec, len(chunks))
+
+    safe = _safe_name(doi)
+    results: List[Dict[str, Any]] = []
+    for idx, score in zip(indices[0], scores[0]):
+        if idx == -1:
+            continue
+        meta = chunks[idx]
+        if meta["doi"] != safe:
+            continue
+        results.append(
+            {
+                "text": meta["text"],
+                "score": float(score),
+                "chunk_id": meta["chunk_id"],
+            }
+        )
+        if len(results) >= k:
+            break
+    return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ reportlab==4.4.2
 fastapi>=0.110.0
 
 openai==1.93.0
+faiss-cpu==1.7.4
+scikit-learn==1.7.0
+numpy<2

--- a/tests/agent2/test_vector_index.py
+++ b/tests/agent2/test_vector_index.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import orjson
+
+from agent2.vector_index import build_vector_index, query_index
+
+
+def create_text_file(dir_path: Path, doi: str, text: str) -> Path:
+    path = dir_path / f"{doi.replace('/', '_')}.json"
+    data = {"pages": [{"page": 1, "text": text}]}
+    path.write_bytes(orjson.dumps(data))
+    return path
+
+
+def test_build_and_query(tmp_path: Path) -> None:
+    text_dir = tmp_path / "text"
+    text_dir.mkdir()
+    file_path = create_text_file(
+        text_dir, "10.1/abc", "Mendelian randomization study results"
+    )
+    index_path = tmp_path / "index.faiss"
+    build_vector_index([file_path], index_path)
+    results = query_index("10.1/abc", "Mendelian", k=1, index_path=index_path)
+    assert results
+    assert "Mendelian".lower() in results[0]["text"].lower()


### PR DESCRIPTION
## Summary
- build and query FAISS index for text snippets
- include new tests for vector index
- document embedding steps in README
- add faiss, scikit‑learn and numpy to requirements

## Testing
- `ruff check . --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863a04987e0832cb827b212d0002fc3