### PR TITLE
Add embedding-aware snippet retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project automates the extraction and synthesis of structured information fr
 - **Text Extraction**: Conversion of PDFs to structured, page-wise text files.
 - **Metadata Extraction (Agent 1)**: Uses the OpenAI API to pull key metadata fields into JSON.
 - **Data Aggregation**: Collates individual metadata JSON files into a master dataset.
-- **Text Retrieval Helper**: Fetches keyword-based snippets from stored PDF text files for downstream RAG tasks.
+- **Text Retrieval Helper**: Retrieves relevant snippets via the embedding index when available, falling back to keyword search.
 - **Text Embeddings**: Splits extracted text into chunks and generates OpenAI embeddings for semantic retrieval.
 - **Embedding Indexing**: Builds a FAISS vector store from extracted text for semantic snippet retrieval.
 - **Embedding-based Retrieval**: Searches the FAISS index for semantically similar text chunks.

--- a/agent2/openai_narrative.py
+++ b/agent2/openai_narrative.py
@@ -58,7 +58,7 @@ class OpenAINarrative:
     def generate(
         self, metadata: List[Dict], snippets: List[str], *, max_retries: int = 2
     ) -> str:
-        """Generate a narrative review from ``metadata`` and ``snippets``."""
+        """Generate Markdown narrative integrating metadata and text snippets."""
         messages = [
             {"role": "system", "content": self.prompt},
             {"role": "user", "content": self._format_input(metadata, snippets)},

--- a/agent2/retrieval.py
+++ b/agent2/retrieval.py
@@ -6,7 +6,10 @@ from typing import List
 
 import orjson
 
+from .vector_index import query_index
+
 TEXT_DIR = Path(__file__).resolve().parents[1] / "data" / "text"
+INDEX_PATH = Path(__file__).resolve().parents[1] / "data" / "index.faiss"
 
 
 def _safe_name(doi: str) -> str:
@@ -21,7 +24,7 @@ def load_pages(doi: str) -> List[dict]:
     return data.get("pages", [])
 
 
-def get_snippets(doi: str, keyword: str, *, window: int = 40) -> List[str]:
+def _keyword_snippets(doi: str, keyword: str, *, window: int = 40) -> List[str]:
     pages = load_pages(doi)
     pattern = re.compile(re.escape(keyword), re.IGNORECASE)
     results: List[str] = []
@@ -33,3 +36,20 @@ def get_snippets(doi: str, keyword: str, *, window: int = 40) -> List[str]:
             snippet = text[start:end].strip()
             results.append(f"Page {page.get('page')}: {snippet}")
     return results
+
+
+def get_snippets(doi: str, drug_name: str, k: int = 5) -> List[str]:
+    """Return up to ``k`` snippets mentioning ``drug_name`` from ``doi``."""
+    results: List[str] = []
+
+    if INDEX_PATH.exists():
+        try:
+            emb = query_index(doi, drug_name, k=k, index_path=INDEX_PATH)
+            results.extend(r.get("text", "").strip() for r in emb if r.get("text"))
+        except Exception:
+            results = []
+
+    if len(results) < k:
+        results.extend(_keyword_snippets(doi, drug_name))
+
+    return results[:k]

--- a/tests/agent2/test_retrieval.py
+++ b/tests/agent2/test_retrieval.py
@@ -23,6 +23,7 @@ def test_successful_snippet_retrieval(tmp_path: Path, monkeypatch) -> None:
     text_dir.mkdir()
     create_text_file(text_dir, "10.1/abc")
     monkeypatch.setattr(retrieval, "TEXT_DIR", text_dir)
+    monkeypatch.setattr(retrieval, "INDEX_PATH", tmp_path / "missing.faiss")
 
     result = retrieval.get_snippets("10.1/abc", "mendelian")
     assert result
@@ -34,6 +35,23 @@ def test_no_matches(tmp_path: Path, monkeypatch) -> None:
     text_dir.mkdir()
     create_text_file(text_dir, "10.2/xyz")
     monkeypatch.setattr(retrieval, "TEXT_DIR", text_dir)
+    monkeypatch.setattr(retrieval, "INDEX_PATH", tmp_path / "missing.faiss")
 
     result = retrieval.get_snippets("10.2/xyz", "unrelated")
     assert result == []
+
+
+def test_embedding_snippets(tmp_path: Path, monkeypatch) -> None:
+    text_dir = tmp_path / "text"
+    text_dir.mkdir()
+    file_path = create_text_file(text_dir, "10.3/emb")
+    index_path = tmp_path / "index.faiss"
+    from agent2.vector_index import build_vector_index
+
+    build_vector_index([file_path], index_path)
+    monkeypatch.setattr(retrieval, "TEXT_DIR", text_dir)
+    monkeypatch.setattr(retrieval, "INDEX_PATH", index_path)
+
+    result = retrieval.get_snippets("10.3/emb", "mendelian", k=1)
+    assert result
+    assert "mendelian" in result[0].lower()


### PR DESCRIPTION
## Summary
- integrate embedding index queries in snippet retrieval with fallback
- include snippet integration explicitly in narrative generation
- adjust README to document retrieval update
- test snippet retrieval with and without FAISS index

## Testing
- `ruff check .`
- `black .`
- `pytest -q` *(fails: OPENAI API access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6863a5daddf8832cbd393abf3cecbc9f