### PR TITLE
Add CLI for building OpenAI embedding index

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Below is a brief description of the main scripts and where their outputs are wri
 - `agent2/retrieval.py` returns relevant snippets from page text or the FAISS embedding index.
 - `agent2/embeddings.py` provides helpers for chunking text and generating
   embedding vectors via OpenAI.
+- `create_embeddings.py` builds a FAISS index of OpenAI embeddings from the
+  extracted text files. Use `--model` to choose the embedding model.
 - `agent2/vector_index.py` builds and queries the FAISS index used for semantic snippet retrieval.
 - `agent2/openai_narrative.py` uses the OpenAI API to turn metadata and
   snippets into a narrative review string.
@@ -123,22 +125,16 @@ python extract/pdf_to_text.py path/to/paper.pdf
 ```
 Both commands expect a single PDF file path and should be run for every paper.
 
-3. Build the embedding index from the extracted text:
+3. Build the embedding index from the extracted text using OpenAI embeddings:
 
 ```bash
-python - <<'EOF'
-from pathlib import Path
-from agent2.vector_index import build_vector_index
-
-text_dir = Path("data/text")
-index = Path("data/index.faiss")
-build_vector_index(list(text_dir.glob("*.json")), index)
-EOF
+python create_embeddings.py --text-dir data/text --index data/index.faiss \
+    --model text-embedding-3-small
 ```
 
-This indexing step uses local TF‑IDF vectors and does not call the OpenAI API.
-The resulting `data/index.faiss` and its metadata can be reused across
-pipeline runs, so you only need to build the index once per corpus.
+This step calls the OpenAI API to generate embeddings. The resulting
+`data/index.faiss` and metadata files can be reused across runs, so you only
+need to build the index once per corpus.
 
 4. Execute Agent 1 to extract metadata by pointing it to a text JSON file:
 

--- a/agent2/embeddings.py
+++ b/agent2/embeddings.py
@@ -50,7 +50,9 @@ def chunk_text(text: str, chunk_size: int = 512, overlap: int = 64) -> List[str]
     return chunks
 
 
-def embed_chunks(chunks: List[str]) -> List[List[float]]:
+def embed_chunks(
+    chunks: List[str], *, model: str = "text-embedding-3-small"
+) -> List[List[float]]:
     """Generate embeddings for each text chunk using OpenAI's embeddings API."""
     if not chunks:
         return []
@@ -61,7 +63,7 @@ def embed_chunks(chunks: List[str]) -> List[List[float]]:
         start_time = time.time()
         try:
             response = client.embeddings.create(
-                model="text-embedding-3-small",
+                model=model,
                 input=chunks,
             )
         except AuthError as exc:  # pragma: no cover - auth errors

--- a/agent2/openai_index.py
+++ b/agent2/openai_index.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict, Any
+
+import numpy as np
+import orjson
+import faiss
+
+from .embeddings import chunk_text, embed_chunks
+
+
+def build_openai_index(
+    text_json_paths: List[Path],
+    index_path: Path,
+    *,
+    model: str = "text-embedding-3-small",
+    batch_size: int = 100,
+) -> None:
+    """Build a FAISS index from text files using OpenAI embeddings."""
+    chunks: List[Dict[str, Any]] = []
+    for path in text_json_paths:
+        data = orjson.loads(path.read_bytes())
+        pages = data.get("pages", [])
+        text = " ".join(p.get("text", "") for p in pages)
+        for idx, chunk in enumerate(chunk_text(text)):
+            chunks.append(
+                {
+                    "text": chunk,
+                    "chunk_id": f"{path.stem}_{idx}",
+                    "doi": path.stem,
+                }
+            )
+
+    if not chunks:
+        return
+
+    embeddings: List[List[float]] = []
+    for start in range(0, len(chunks), batch_size):
+        batch = [c["text"] for c in chunks[start : start + batch_size]]
+        embeddings.extend(embed_chunks(batch, model=model))
+
+    matrix = np.array(embeddings, dtype="float32")
+    faiss.normalize_L2(matrix)
+    index = faiss.IndexFlatIP(matrix.shape[1])
+    index.add(matrix)
+
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    faiss.write_index(index, str(index_path))
+    index_path.with_suffix(".meta.json").write_bytes(orjson.dumps(chunks))
+
+
+def query_index(
+    doi: str,
+    query: str,
+    *,
+    k: int = 5,
+    index_path: Path | None = None,
+    model: str = "text-embedding-3-small",
+) -> List[Dict[str, Any]]:
+    """Return top-k snippets for ``doi`` most similar to ``query``."""
+    if index_path is None:
+        raise ValueError("index_path is required")
+    if not index_path.exists():
+        raise FileNotFoundError(index_path)
+
+    index = faiss.read_index(str(index_path))
+    chunks = orjson.loads(index_path.with_suffix(".meta.json").read_bytes())
+
+    query_vec = np.array([embed_chunks([query], model=model)[0]], dtype="float32")
+    faiss.normalize_L2(query_vec)
+    scores, indices = index.search(query_vec, len(chunks))
+
+    safe = doi.replace("/", "_").replace(":", "_")
+    results: List[Dict[str, Any]] = []
+    for idx, score in zip(indices[0], scores[0]):
+        if idx == -1:
+            continue
+        meta = chunks[idx]
+        if meta["doi"] != safe:
+            continue
+        results.append(
+            {
+                "text": meta["text"],
+                "score": float(score),
+                "chunk_id": meta["chunk_id"],
+            }
+        )
+        if len(results) >= k:
+            break
+    return results

--- a/create_embeddings.py
+++ b/create_embeddings.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from agent2.openai_index import build_openai_index
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for building the OpenAI embedding index."""
+    parser = argparse.ArgumentParser(description="Create text embedding index")
+    parser.add_argument(
+        "--text-dir",
+        default="data/text",
+        help="Directory containing extracted text JSON files",
+    )
+    parser.add_argument(
+        "--index",
+        default="data/index.faiss",
+        help="Path to write the FAISS index",
+    )
+    parser.add_argument(
+        "--model",
+        default="text-embedding-3-small",
+        help="OpenAI embedding model",
+    )
+    args = parser.parse_args(argv)
+
+    text_dir = Path(args.text_dir)
+    index_path = Path(args.index)
+    paths = list(text_dir.glob("*.json"))
+    build_openai_index(paths, index_path, model=args.model)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent2/test_openai_index.py
+++ b/tests/agent2/test_openai_index.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+import orjson
+
+import agent2.openai_index as oi
+import create_embeddings
+
+
+def create_text_file(dir_path: Path, doi: str, text: str) -> Path:
+    path = dir_path / f"{doi.replace('/', '_')}.json"
+    data = {"pages": [{"page": 1, "text": text}]}
+    path.write_bytes(orjson.dumps(data))
+    return path
+
+
+def test_build_openai_index(tmp_path, monkeypatch):
+    text_dir = tmp_path / "text"
+    text_dir.mkdir()
+    file_path = create_text_file(text_dir, "10.1/abc", "some text")
+    index_path = tmp_path / "index.faiss"
+
+    monkeypatch.setattr(
+        oi, "embed_chunks", lambda chunks, model="m": [[0.1, 0.2] for _ in chunks]
+    )
+
+    oi.build_openai_index([file_path], index_path, model="m")
+    assert index_path.exists()
+    assert index_path.with_suffix(".meta.json").exists()
+
+
+def test_cli_main(tmp_path, monkeypatch):
+    text_dir = tmp_path / "text"
+    text_dir.mkdir()
+    (text_dir / "a.json").write_text("{}")
+
+    calls = {}
+
+    def fake_build(paths, index_path, model="x"):
+        calls["count"] = len(paths)
+        calls["index"] = index_path
+        calls["model"] = model
+
+    monkeypatch.setattr("create_embeddings.build_openai_index", fake_build)
+
+    code = create_embeddings.main(
+        [
+            "--text-dir",
+            str(text_dir),
+            "--index",
+            str(tmp_path / "idx.faiss"),
+            "--model",
+            "m",
+        ]
+    )
+
+    assert code == 0
+    assert calls == {
+        "count": 1,
+        "index": Path(tmp_path / "idx.faiss"),
+        "model": "m",
+    }


### PR DESCRIPTION
## Summary
- extend `embed_chunks` with model argument
- implement OpenAI-based FAISS indexing utilities
- add `create_embeddings.py` script for building embeddings index
- document new command in README
- add tests for building the index and CLI

## Testing
- `black . --quiet`
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ddbdd714832c92856c7efceb190f