### PR TITLE
Add explicit retrieval method option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Below is a brief description of the main scripts and where their outputs are wri
   directory.
 - `pipeline.py` and `run_pipeline.py` orchestrate the entire workflow—ingestion,
   metadata extraction, aggregation and narrative generation—when run from the
-  command line. Use the `--agent1-model`, `--agent2-model` and `--embed-model` options to override the default OpenAI models for metadata extraction, narrative generation and snippet embeddings respectively.
+  command line. Use the `--agent1-model`, `--agent2-model` and `--embed-model`
+  options to override the default OpenAI models. The `--retrieval` option
+  selects either the `faiss` index or plain text search for snippet retrieval.
 - `run_smoke_test.py` ingests a single PDF and prints the first few hundred
   characters from each page as a quick sanity check.
 - `utils/data_wipe.py` deletes generated data and logs. Pass `--with-pdfs` to
@@ -192,7 +194,8 @@ python run_pipeline.py \
     --drug <drug-name> \
     --agent1-model <agent1> \
     --agent2-model <agent2> \
-    --embed-model <embed>
+    --embed-model <embed> \
+    --retrieval faiss
 ```
 
 ## Output

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,6 +13,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--agent1-model", help="Model for metadata extraction")
     parser.add_argument("--agent2-model", help="Model for narrative generation")
     parser.add_argument("--embed-model", help="Model for text embeddings")
+    parser.add_argument(
+        "--retrieval",
+        choices=["faiss", "text"],
+        default="faiss",
+        help="Snippet retrieval backend (default: faiss)",
+    )
     args = parser.parse_args(argv)
     pipeline.run_pipeline(
         args.pdf_dir,
@@ -20,6 +26,7 @@ def main(argv: list[str] | None = None) -> int:
         agent1_model=args.agent1_model,
         agent2_model=args.agent2_model,
         embed_model=args.embed_model,
+        retrieval_method=args.retrieval,
     )
     return 0
 

--- a/tests/agent2/test_retrieval.py
+++ b/tests/agent2/test_retrieval.py
@@ -25,7 +25,7 @@ def test_successful_snippet_retrieval(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(retrieval, "TEXT_DIR", text_dir)
     monkeypatch.setattr(retrieval, "INDEX_PATH", tmp_path / "missing.faiss")
 
-    result = retrieval.get_snippets("10.1/abc", "mendelian")
+    result = retrieval.get_snippets("10.1/abc", "mendelian", method="text")
     assert result
     assert any("Page 1" in s for s in result)
 
@@ -37,7 +37,7 @@ def test_no_matches(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(retrieval, "TEXT_DIR", text_dir)
     monkeypatch.setattr(retrieval, "INDEX_PATH", tmp_path / "missing.faiss")
 
-    result = retrieval.get_snippets("10.2/xyz", "unrelated")
+    result = retrieval.get_snippets("10.2/xyz", "unrelated", method="text")
     assert result == []
 
 
@@ -56,6 +56,6 @@ def test_embedding_snippets(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(retrieval, "TEXT_DIR", text_dir)
     monkeypatch.setattr(retrieval, "INDEX_PATH", index_path)
 
-    result = retrieval.get_snippets("10.3/emb", "mendelian", k=1)
+    result = retrieval.get_snippets("10.3/emb", "mendelian", k=1, method="faiss")
     assert result
     assert "mendelian" in result[0].lower()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -66,7 +66,7 @@ def test_run_pipeline(monkeypatch, tmp_path):
     fake = FakeNarrative()
     monkeypatch.setattr("pipeline.OpenAINarrative", lambda *a, **k: fake)
 
-    pipeline.run_pipeline(str(pdf_dir), "test")
+    pipeline.run_pipeline(str(pdf_dir), "test", retrieval_method="text")
 
     assert (tmp_path / "master.json").exists()
     out_file = tmp_path / "out" / "review_test.md"

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -61,6 +61,8 @@ def test_full_pipeline_cli(monkeypatch, tmp_path: Path) -> None:
             "a2",
             "--embed-model",
             "e",
+            "--retrieval",
+            "text",
         ]
     )
     assert code == 0

--- a/tests/test_run_pipeline_cli.py
+++ b/tests/test_run_pipeline_cli.py
@@ -13,12 +13,14 @@ def test_main_invokes_pipeline(monkeypatch):
         agent1_model: str | None,
         agent2_model: str | None,
         embed_model: str | None,
+        retrieval_method: str,
     ) -> None:
         calls["pdf_dir"] = pdf_dir
         calls["drug"] = drug
         calls["agent1_model"] = agent1_model
         calls["agent2_model"] = agent2_model
         calls["embed_model"] = embed_model
+        calls["retrieval_method"] = retrieval_method
 
     monkeypatch.setattr("pipeline.run_pipeline", fake_run)
 
@@ -34,6 +36,8 @@ def test_main_invokes_pipeline(monkeypatch):
             "a2",
             "--embed-model",
             "e",
+            "--retrieval",
+            "faiss",
         ]
     )
     assert code == 0
@@ -43,4 +47,5 @@ def test_main_invokes_pipeline(monkeypatch):
         "agent1_model": "a1",
         "agent2_model": "a2",
         "embed_model": "e",
+        "retrieval_method": "faiss",
     }


### PR DESCRIPTION
## Summary
- add `--retrieval` CLI argument to `run_pipeline.py` and `pipeline.py`
- support choosing FAISS index or plain text search in `agent2.retrieval`
- update unit tests for new parameter
- document retrieval option in README

## Testing
- `ruff check .`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e52cc7e8832c9e1a7c772e8cb50f