### PR TITLE
Skip live OpenAI tests

### DIFF
--- a/tests/agent2/test_openai_narrative_live.py
+++ b/tests/agent2/test_openai_narrative_live.py
@@ -10,6 +10,7 @@ from utils.secrets import get_openai_api_key
 from tests.openai_test_utils import handle_openai_exception
 
 
+@pytest.mark.skip(reason="Live API call too expensive to run every time")
 def test_openai_narrative_live():
     try:
         get_openai_api_key()
@@ -25,3 +26,17 @@ def test_openai_narrative_live():
         handle_openai_exception(exc)
         return
     assert isinstance(result, str) and result.strip()
+
+
+def test_openai_narrative_offline(monkeypatch):
+    """Offline version that bypasses the real API."""
+
+    monkeypatch.setattr(
+        OpenAINarrative,
+        "generate",
+        lambda self, metadata, snippets, max_retries=2: "review",
+    )
+
+    narrative = OpenAINarrative(model="test")
+    result = narrative.generate([{"title": "T"}], ["s1"])
+    assert result == "review"

--- a/tests/integration/test_real_pdfs.py
+++ b/tests/integration/test_real_pdfs.py
@@ -17,6 +17,7 @@ if "openai" in sys.modules:
         importlib.reload(module)
 
 
+@pytest.mark.skip(reason="Live API call too expensive to run every time")
 @pytest.mark.parametrize("pdf_path", sorted(Path("data/pdfs").glob("*.pdf")))
 def test_full_extraction_real_file(
     tmp_path: Path, pdf_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -42,6 +43,7 @@ def test_full_extraction_real_file(
     PaperMetadata.model_validate(meta.model_dump())
 
 
+@pytest.mark.skip(reason="Live API call too expensive to run every time")
 @pytest.mark.parametrize("pdf_path", sorted(Path("data/pdfs").glob("*.pdf")))
 def test_metadata_extractor_prompt_decode_error(
     tmp_path: Path, pdf_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -65,6 +67,7 @@ def test_metadata_extractor_prompt_decode_error(
     MetadataExtractor()
 
 
+@pytest.mark.skip(reason="Live API call too expensive to run every time")
 def test_run_pipeline_real(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     import pipeline
 
@@ -84,7 +87,91 @@ def test_run_pipeline_real(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr("agent2.retrieval.TEXT_DIR", tmp_path / "text")
     monkeypatch.setattr("pipeline.OUTPUT_DIR", tmp_path / "out")
 
-    pipeline.run_pipeline("data/pdfs", "sglt2i")
+    pipeline.run_pipeline("data/pdfs", "sglt2i", retrieval_method="text")
+
+    master = tmp_path / "master.json"
+    assert master.exists()
+    data = master.read_bytes()
+    assert data
+    out_file = tmp_path / "out" / "review_sglt2i.md"
+    assert out_file.exists()
+
+
+class FakeClient:
+    def call(self, *_args, **_kwargs):
+        return {"title": "T", "doi": "10.1/test"}
+
+
+class FakeNarrative:
+    def generate(self, *_args, **_kwargs):
+        return "# Review"
+
+
+@pytest.mark.parametrize("pdf_path", sorted(Path("data/pdfs").glob("*.pdf")))
+def test_full_extraction_real_file_offline(
+    tmp_path: Path, pdf_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("extract.pdf_to_text.DATA_DIR", tmp_path / "text")
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+
+    ingest_pdf(pdf_path)
+    text_data = pdf_to_text(pdf_path)
+    assert text_data.pages
+
+    from agent1.metadata_extractor import MetadataExtractor
+
+    extractor = MetadataExtractor(client=FakeClient())
+    meta = extractor.extract(tmp_path / "text" / f"{pdf_path.stem}.json", "Drug")
+    assert meta is not None
+    PaperMetadata.model_validate(meta.model_dump())
+
+
+@pytest.mark.parametrize("pdf_path", sorted(Path("data/pdfs").glob("*.pdf")))
+def test_metadata_extractor_prompt_decode_error_offline(
+    tmp_path: Path, pdf_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("extract.pdf_to_text.DATA_DIR", tmp_path / "text")
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+    pdf_to_text(pdf_path)
+
+    import agent1.openai_client as oc
+
+    original_read_text = oc.Path.read_text
+
+    def cp1252_read_text(self, *args, **kwargs):
+        return original_read_text(self, encoding="cp1252")
+
+    monkeypatch.setattr(oc.Path, "read_text", cp1252_read_text)
+
+    from agent1.metadata_extractor import MetadataExtractor
+
+    MetadataExtractor(client=FakeClient())
+
+
+def test_run_pipeline_real_offline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import pipeline
+    from agent1.metadata_extractor import MetadataExtractor
+
+    monkeypatch.setattr("ingest.collector.LOG_PATH", tmp_path / "log.jsonl")
+    monkeypatch.setattr("extract.pdf_to_text.DATA_DIR", tmp_path / "text")
+    monkeypatch.setattr("pipeline.TEXT_DIR", tmp_path / "text")
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+    monkeypatch.setattr("aggregate.META_DIR", tmp_path / "meta")
+    monkeypatch.setattr("aggregate.MASTER_PATH", tmp_path / "master.json")
+    monkeypatch.setattr("aggregate.HISTORY_DIR", tmp_path / "history")
+    monkeypatch.setattr("agent2.retrieval.TEXT_DIR", tmp_path / "text")
+    monkeypatch.setattr("pipeline.OUTPUT_DIR", tmp_path / "out")
+
+    monkeypatch.setattr(
+        pipeline,
+        "MetadataExtractor",
+        lambda *a, **k: MetadataExtractor(client=FakeClient()),
+    )
+    monkeypatch.setattr(pipeline, "OpenAINarrative", lambda *a, **k: FakeNarrative())
+
+    pipeline.run_pipeline("data/pdfs", "sglt2i", retrieval_method="text")
 
     master = tmp_path / "master.json"
     assert master.exists()

--- a/tests/test_network_access.py
+++ b/tests/test_network_access.py
@@ -3,6 +3,7 @@ import urllib.error
 import pytest
 
 
+@pytest.mark.skip(reason="Live API call too expensive to run every time")
 def test_api_openai_network_access():
     url = "https://api.openai.com/v1/models"
     try:
@@ -14,3 +15,28 @@ def test_api_openai_network_access():
         pytest.skip(f"Network access to api.openai.com failed: {exc}")
         return
     assert status in {200, 401, 404}
+
+
+def test_api_openai_network_access_offline(monkeypatch):
+    """Offline test that simulates an HTTP 200 response."""
+
+    class FakeResponse:
+        def __init__(self, status: int = 200) -> None:
+            self.status = status
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda *a, **k: FakeResponse(200),
+    )
+
+    url = "https://api.openai.com/v1/models"
+    with urllib.request.urlopen(url, timeout=5) as resp:
+        status = resp.status
+    assert status == 200

--- a/tests/test_openai_api_connection.py
+++ b/tests/test_openai_api_connection.py
@@ -9,6 +9,7 @@ from utils.secrets import get_openai_api_key
 from tests.openai_test_utils import handle_openai_exception
 
 
+@pytest.mark.skip(reason="Live API call too expensive to run every time")
 def test_openai_api_connection():
     try:
         api_key = get_openai_api_key()
@@ -27,3 +28,33 @@ def test_openai_api_connection():
         return
 
     assert response.choices[0].message.content
+
+
+def test_openai_api_connection_offline(monkeypatch):
+    """Offline version that avoids real API calls."""
+    import types
+
+    monkeypatch.setattr("utils.secrets.get_openai_api_key", lambda: "key")
+
+    class FakeChat:
+        def create(self, *args, **kwargs):
+            return types.SimpleNamespace(
+                choices=[
+                    types.SimpleNamespace(message=types.SimpleNamespace(content="hi"))
+                ]
+            )
+
+    fake_client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=FakeChat())
+    )
+
+    monkeypatch.setattr(openai, "OpenAI", lambda api_key=None: fake_client)
+
+    api_key = get_openai_api_key()
+    client = openai.OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "Say hello"}],
+        max_tokens=1,
+    )
+    assert response.choices[0].message.content == "hi"

--- a/tests/test_openai_json_caller_live.py
+++ b/tests/test_openai_json_caller_live.py
@@ -5,6 +5,7 @@ from tests.openai_test_utils import handle_openai_exception
 from schemas.metadata import PaperMetadata
 
 
+@pytest.mark.skip(reason="Live API call too expensive to run every time")
 def test_openai_json_caller_live():
     try:
         get_openai_api_key()
@@ -36,3 +37,21 @@ def test_openai_json_caller_live():
         "p_threshold",
         "ld_r2",
     }
+
+
+def test_openai_json_caller_offline(monkeypatch):
+    """Offline version that bypasses the real API."""
+
+    monkeypatch.setattr(
+        OpenAIJSONCaller,
+        "call",
+        lambda self, _text, max_retries=2: {
+            "title": "T",
+            "doi": "10.1/example",
+        },
+    )
+
+    caller = OpenAIJSONCaller(model="test")
+    result = caller.call("hello")
+    PaperMetadata.model_validate(result)
+    assert result["title"] == "T"


### PR DESCRIPTION
## Summary
- mark tests that hit the OpenAI API as skipped
- provide offline versions of those tests using mocks
- avoid network calls in integration tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e8751ef4832c93667e70cb2d0a2c