### PR TITLE
Refactor pipeline to support per-drug directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Below is a brief description of the main scripts and where their outputs are wri
 - `agent2/retrieval.py` returns relevant snippets from page text or the FAISS embedding index.
 - `agent2/embeddings.py` provides helpers for chunking text and generating
   embedding vectors via OpenAI.
-- `create_embeddings.py` builds a FAISS index of OpenAI embeddings from the
-  extracted text files. Use `--model` to choose the embedding model.
+- `build_embeddings.py` builds a FAISS index of OpenAI embeddings from the
+  extracted text files under a chosen base directory. Use `--model` to choose the embedding model.
 - `agent2/openai_index.py` builds and queries the FAISS index used for semantic
   snippet retrieval.
 - `agent2/openai_narrative.py` uses the OpenAI API to turn metadata and
@@ -131,8 +131,7 @@ Both commands expect a single PDF file path and should be run for every paper.
 3. Build the embedding index from the extracted text using OpenAI embeddings:
 
 ```bash
-python create_embeddings.py --text-dir data/text --index data/index.faiss \
-    --model text-embedding-3-small
+python build_embeddings.py --base_dir data --model text-embedding-3-small
 ```
 
 This step calls the OpenAI API to generate embeddings. The resulting
@@ -192,6 +191,7 @@ python agent2/synthesiser.py --drug <drug-name>
 python run_pipeline.py \
     --pdf_dir data/pdfs \
     --drug <drug-name> \
+    --base_dir data \
     --agent1-model <agent1> \
     --agent2-model <agent2> \
     --embed-model <embed> \

--- a/agent2/retrieval.py
+++ b/agent2/retrieval.py
@@ -8,8 +8,16 @@ import orjson
 
 from .openai_index import query_index
 
-TEXT_DIR = Path(__file__).resolve().parents[1] / "data" / "text"
-INDEX_PATH = Path(__file__).resolve().parents[1] / "data" / "index.faiss"
+BASE_DIR = Path("data")
+TEXT_DIR = BASE_DIR / "text"
+INDEX_PATH = BASE_DIR / "index.faiss"
+
+
+def set_base_dir(base_dir: Path) -> None:
+    global BASE_DIR, TEXT_DIR, INDEX_PATH
+    BASE_DIR = Path(base_dir)
+    TEXT_DIR = BASE_DIR / "text"
+    INDEX_PATH = BASE_DIR / "index.faiss"
 
 
 def _safe_name(doi: str) -> str:

--- a/agent2/synthesiser.py
+++ b/agent2/synthesiser.py
@@ -9,9 +9,16 @@ import orjson
 from agent2 import retrieval
 from agent2.openai_narrative import OpenAINarrative
 
-DATA_DIR = Path(__file__).resolve().parents[1] / "data"
-MASTER_PATH = DATA_DIR / "master.json"
-OUTPUT_DIR = Path(__file__).resolve().parents[1] / "outputs"
+BASE_DIR = Path("data")
+MASTER_PATH = BASE_DIR / "master.json"
+OUTPUT_DIR = BASE_DIR / "outputs"
+
+
+def set_base_dir(base_dir: Path) -> None:
+    global BASE_DIR, MASTER_PATH, OUTPUT_DIR
+    BASE_DIR = Path(base_dir)
+    MASTER_PATH = BASE_DIR / "master.json"
+    OUTPUT_DIR = BASE_DIR / "outputs"
 
 
 def load_master() -> List[Dict]:

--- a/aggregate.py
+++ b/aggregate.py
@@ -13,11 +13,21 @@ from pydantic import ValidationError
 from schemas.metadata import PaperMetadata
 
 
-DATA_DIR = Path(__file__).resolve().parent / "data"
-META_DIR = DATA_DIR / "meta"
-MASTER_PATH = DATA_DIR / "master.json"
-HISTORY_DIR = DATA_DIR / "master_history"
-ERROR_LOG = DATA_DIR / "aggregation_errors.log"
+BASE_DIR = Path("data")
+META_DIR = BASE_DIR / "meta"
+MASTER_PATH = BASE_DIR / "master.json"
+HISTORY_DIR = BASE_DIR / "master_history"
+ERROR_LOG = BASE_DIR / "aggregation_errors.log"
+
+
+def set_base_dir(base_dir: Path) -> None:
+    """Update all path constants to live under ``base_dir``."""
+    global BASE_DIR, META_DIR, MASTER_PATH, HISTORY_DIR, ERROR_LOG
+    BASE_DIR = Path(base_dir)
+    META_DIR = BASE_DIR / "meta"
+    MASTER_PATH = BASE_DIR / "master.json"
+    HISTORY_DIR = BASE_DIR / "master_history"
+    ERROR_LOG = BASE_DIR / "aggregation_errors.log"
 
 
 def _log_error(path: Path, exc: Exception) -> None:
@@ -72,7 +82,7 @@ def main() -> None:
     else:
         print("Skipped 0 invalid metadata files.")
     if backup is not None:
-        rel_backup = backup.relative_to(DATA_DIR)
+        rel_backup = backup.relative_to(BASE_DIR)
         print(f"Backup created: {rel_backup}")
 
 

--- a/build_embeddings.py
+++ b/build_embeddings.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from agent2.openai_index import build_openai_index
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI for creating the embedding index under a base directory."""
+    parser = argparse.ArgumentParser(description="Build embeddings index")
+    parser.add_argument(
+        "--base_dir",
+        default="data",
+        help="Pipeline base directory (default: data)",
+    )
+    parser.add_argument(
+        "--model",
+        default="text-embedding-3-small",
+        help="OpenAI embedding model",
+    )
+    args = parser.parse_args(argv)
+
+    base = Path(args.base_dir)
+    text_dir = base / "text"
+    index_path = base / "index.faiss"
+    paths = list(text_dir.glob("*.json"))
+    build_openai_index(paths, index_path, model=args.model)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/HOW_TO_ADD_NEW_DRUG.md
+++ b/docs/HOW_TO_ADD_NEW_DRUG.md
@@ -10,7 +10,8 @@ This guide explains how to prepare PDFs, run the processing pipeline, and review
 Run the end-to-end pipeline from the repository root:
 
 ```bash
-python run_pipeline.py --pdf_dir data/new_pdfs --drug <your_drug_name>
+python run_pipeline.py --pdf_dir data/new_pdfs --drug <your_drug_name> \
+    --base_dir data/<your_drug_name>
 ```
 
 Ensure the OpenAI API key is available via ``OPENAI_API_KEY`` or the secret file ``/run/secrets/openai_api_key`` and that you've installed the dependencies from ``requirements.txt``.

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 
+from pathlib import Path
+
 import pipeline
 
 
@@ -10,6 +12,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run MR literature pipeline.")
     parser.add_argument("--pdf_dir", required=True, help="Directory containing PDFs")
     parser.add_argument("--drug", required=True, help="Name of the drug for review")
+    parser.add_argument(
+        "--base_dir",
+        default="data",
+        help="Base output directory (default: data)",
+    )
     parser.add_argument("--agent1-model", help="Model for metadata extraction")
     parser.add_argument("--agent2-model", help="Model for narrative generation")
     parser.add_argument("--embed-model", help="Model for text embeddings")
@@ -23,6 +30,7 @@ def main(argv: list[str] | None = None) -> int:
     pipeline.run_pipeline(
         args.pdf_dir,
         args.drug,
+        base_dir=Path(args.base_dir),
         agent1_model=args.agent1_model,
         agent2_model=args.agent2_model,
         embed_model=args.embed_model,

--- a/tests/agent2/test_openai_index.py
+++ b/tests/agent2/test_openai_index.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import orjson
 
 import agent2.openai_index as oi
-import create_embeddings
+import build_embeddings
 
 
 def create_text_file(dir_path: Path, doi: str, text: str) -> Path:
@@ -39,22 +39,13 @@ def test_cli_main(tmp_path, monkeypatch):
         calls["index"] = index_path
         calls["model"] = model
 
-    monkeypatch.setattr("create_embeddings.build_openai_index", fake_build)
+    monkeypatch.setattr("build_embeddings.build_openai_index", fake_build)
 
-    code = create_embeddings.main(
-        [
-            "--text-dir",
-            str(text_dir),
-            "--index",
-            str(tmp_path / "idx.faiss"),
-            "--model",
-            "m",
-        ]
-    )
+    code = build_embeddings.main(["--base_dir", str(tmp_path), "--model", "m"])
 
     assert code == 0
     assert calls == {
         "count": 1,
-        "index": Path(tmp_path / "idx.faiss"),
+        "index": Path(tmp_path / "index.faiss"),
         "model": "m",
     }

--- a/tests/integration/test_real_pdfs.py
+++ b/tests/integration/test_real_pdfs.py
@@ -87,7 +87,9 @@ def test_run_pipeline_real(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr("agent2.retrieval.TEXT_DIR", tmp_path / "text")
     monkeypatch.setattr("pipeline.OUTPUT_DIR", tmp_path / "out")
 
-    pipeline.run_pipeline("data/pdfs", "sglt2i", retrieval_method="text")
+    pipeline.run_pipeline(
+        "data/pdfs", "sglt2i", base_dir=tmp_path, retrieval_method="text"
+    )
 
     master = tmp_path / "master.json"
     assert master.exists()
@@ -171,7 +173,9 @@ def test_run_pipeline_real_offline(
     )
     monkeypatch.setattr(pipeline, "OpenAINarrative", lambda *a, **k: FakeNarrative())
 
-    pipeline.run_pipeline("data/pdfs", "sglt2i", retrieval_method="text")
+    pipeline.run_pipeline(
+        "data/pdfs", "sglt2i", base_dir=tmp_path, retrieval_method="text"
+    )
 
     master = tmp_path / "master.json"
     assert master.exists()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -66,7 +66,9 @@ def test_run_pipeline(monkeypatch, tmp_path):
     fake = FakeNarrative()
     monkeypatch.setattr("pipeline.OpenAINarrative", lambda *a, **k: fake)
 
-    pipeline.run_pipeline(str(pdf_dir), "test", retrieval_method="text")
+    pipeline.run_pipeline(
+        str(pdf_dir), "test", base_dir=tmp_path, retrieval_method="text"
+    )
 
     assert (tmp_path / "master.json").exists()
     out_file = tmp_path / "out" / "review_test.md"

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -55,6 +55,8 @@ def test_full_pipeline_cli(monkeypatch, tmp_path: Path) -> None:
             str(pdf_dir),
             "--drug",
             "TestDrug",
+            "--base_dir",
+            str(tmp_path),
             "--agent1-model",
             "a1",
             "--agent2-model",

--- a/tests/test_run_pipeline_cli.py
+++ b/tests/test_run_pipeline_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import run_pipeline
 
 
@@ -10,6 +12,7 @@ def test_main_invokes_pipeline(monkeypatch):
         pdf_dir: str,
         drug: str,
         *,
+        base_dir: Path,
         agent1_model: str | None,
         agent2_model: str | None,
         embed_model: str | None,
@@ -17,6 +20,7 @@ def test_main_invokes_pipeline(monkeypatch):
     ) -> None:
         calls["pdf_dir"] = pdf_dir
         calls["drug"] = drug
+        calls["base_dir"] = base_dir
         calls["agent1_model"] = agent1_model
         calls["agent2_model"] = agent2_model
         calls["embed_model"] = embed_model
@@ -30,6 +34,8 @@ def test_main_invokes_pipeline(monkeypatch):
             "data/pdfs",
             "--drug",
             "rapa",
+            "--base_dir",
+            "data",
             "--agent1-model",
             "a1",
             "--agent2-model",
@@ -48,4 +54,5 @@ def test_main_invokes_pipeline(monkeypatch):
         "agent2_model": "a2",
         "embed_model": "e",
         "retrieval_method": "faiss",
+        "base_dir": Path("data"),
     }

--- a/utils/json_validator.py
+++ b/utils/json_validator.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 from pathlib import Path
 import orjson
 
-DATA_DIR = Path(__file__).resolve().parents[1] / "data"
-META_DIR = DATA_DIR / "meta"
-MASTER_PATH = DATA_DIR / "master.json"
+BASE_DIR = Path("data")
+META_DIR = BASE_DIR / "meta"
+MASTER_PATH = BASE_DIR / "master.json"
+
+
+def set_base_dir(base_dir: Path) -> None:
+    """Update path constants based on ``base_dir``."""
+    global BASE_DIR, META_DIR, MASTER_PATH
+    BASE_DIR = Path(base_dir)
+    META_DIR = BASE_DIR / "meta"
+    MASTER_PATH = BASE_DIR / "master.json"
 
 
 def validate_file(path: Path) -> bool:


### PR DESCRIPTION
## Summary
- add `--base_dir` option to `run_pipeline.py`
- refactor `pipeline.py` to compute all paths from a base directory
- update helpers and CLIs for configurable output locations
- introduce `build_embeddings.py` CLI
- update docs and tests for new workflow

## Testing
- `ruff check . --fix`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864070a565c832ca9c2740324bf036f