### PR TITLE
Switch default models to GPT‑4o

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Below is a brief description of the main scripts and where their outputs are wri
 - `pipeline.py` and `run_pipeline.py` orchestrate the entire workflow—ingestion,
   metadata extraction, aggregation and narrative generation—when run from the
   command line. Use the `--agent1-model`, `--agent2-model` and `--embed-model`
-  options to override the default OpenAI models. The `--retrieval` option
+  options to override the default OpenAI models. (Agent 1 and Agent 2 default to `gpt-4o-2024-05-13`, embeddings default to `text-embedding-3-small`). The `--retrieval` option
   selects either the `faiss` index or plain text search for snippet retrieval.
 - `run_smoke_test.py` ingests a single PDF and prints the first few hundred
   characters from each page as a quick sanity check.
@@ -197,6 +197,8 @@ python run_pipeline.py \
     --embed-model <embed> \
     --retrieval faiss
 ```
+If not specified, Agent 1 and Agent 2 default to `gpt-4o-2024-05-13`
+and embeddings default to `text-embedding-3-small`.
 
 ## Output
 - Individual metadata JSONs in `data/meta/`.
@@ -236,10 +238,11 @@ Another workflow runs a schema drift unit test to ensure that `PaperMetadata` do
 
 ## API Cost Estimation
 
-The pipeline uses the OpenAI API (for example, GPT-4-Turbo), which is billed per
+The pipeline uses the OpenAI API (for example, GPT-4o), which is billed per
 1,000 tokens. Costs may change, so always check the
 [OpenAI Pricing](https://openai.com/pricing) page for the latest numbers. At the
-time of writing, GPT-4-Turbo is roughly **$0.01 per 1,000 tokens**.
+time of writing, GPT-4o is roughly **$0.005 per 1,000 input tokens** and
+**$0.015 per 1,000 output tokens**.
 
 Estimating cost for a run is easiest when you know roughly how many tokens each
 step consumes:
@@ -248,6 +251,10 @@ step consumes:
   from the API, or about **$0.02 per paper**.
 - **Narrative synthesis**: Producing a narrative review for a single drug usually
   takes 4,000–6,000 tokens (**$0.04–$0.06 per review**).
+
+Embedding generation with `text-embedding-3-small` costs roughly
+**$0.00002 per 1,000 tokens**, so these charges are typically minor compared to
+GPT-4o usage.
 
 For example, processing metadata for 100 papers would cost approximately:
 

--- a/agent1/metadata_extractor.py
+++ b/agent1/metadata_extractor.py
@@ -26,7 +26,7 @@ class MetadataExtractor:
         self,
         client: Optional[OpenAIJSONCaller] = None,
         *,
-        model: str = "gpt-4-0125-preview",
+        model: str = "gpt-4o-2024-05-13",
     ) -> None:
         self.client = client or OpenAIJSONCaller(model=model)
         META_DIR.mkdir(parents=True, exist_ok=True)

--- a/agent1/openai_client.py
+++ b/agent1/openai_client.py
@@ -50,7 +50,7 @@ def _usage_get(usage: Any, key: str) -> Any:
 class OpenAIJSONCaller:
     """Helper for calling OpenAI's chat completion API in JSON mode."""
 
-    def __init__(self, model: str = "gpt-4-0125-preview") -> None:
+    def __init__(self, model: str = "gpt-4o-2024-05-13") -> None:
         self.model = model
         with PROMPT_PATH.open("r", encoding="utf-8") as f:
             self.prompt = f.read()

--- a/agent2/openai_narrative.py
+++ b/agent2/openai_narrative.py
@@ -44,7 +44,7 @@ def _usage_get(usage, key):
 class OpenAINarrative:
     """Helper for generating narrative reviews using OpenAI."""
 
-    def __init__(self, model: str = "gpt-4-0125-preview") -> None:
+    def __init__(self, model: str = "gpt-4o-2024-05-13") -> None:
         self.model = model
         with PROMPT_PATH.open("r", encoding="utf-8") as f:
             self.prompt = f.read()


### PR DESCRIPTION
## Summary
- update Agent 1 JSON caller default model
- update metadata extractor default model
- update Agent 2 narrative generator default model
- document new defaults and embedding pricing in README

## Testing
- `black .`
- `ruff check .`
- `OPENAI_API_KEY=sk pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640db85a54832cb759e8284eb0d5e0