### PR TITLE
Fix pipeline path resets between runs

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -155,18 +155,15 @@ def run_pipeline(
     """Execute the full data processing pipeline."""
     dirs = make_dirs(base_dir)
     global TEXT_DIR, OUTPUT_DIR
-    if TEXT_DIR == DEFAULT_TEXT_DIR:
+    # Adjust helper module paths if they do not already point inside ``base_dir``.
+    if not TEXT_DIR.resolve().is_relative_to(dirs.base):
         TEXT_DIR = dirs.text
-    if OUTPUT_DIR == DEFAULT_OUTPUT_DIR:
+    if not OUTPUT_DIR.resolve().is_relative_to(dirs.base):
         OUTPUT_DIR = dirs.outputs
-    if meta_mod.META_DIR == DEFAULT_META_DIR:
+    if not meta_mod.META_DIR.resolve().is_relative_to(dirs.base):
         meta_mod.META_DIR = dirs.meta
-    if aggregate.META_DIR == DEFAULT_META_DIR:
-        aggregate.META_DIR = dirs.meta
-    if aggregate.MASTER_PATH == DEFAULT_MASTER_PATH:
-        aggregate.MASTER_PATH = dirs.master
-    if aggregate.HISTORY_DIR == DEFAULT_HISTORY_DIR:
-        aggregate.HISTORY_DIR = dirs.history
+    if not aggregate.META_DIR.resolve().is_relative_to(dirs.base):
+        aggregate.set_base_dir(dirs.base)
     retrieval.TEXT_DIR = dirs.text
     retrieval.INDEX_PATH = dirs.index
     metrics: Dict[str, StepMetrics] = {}


### PR DESCRIPTION
## Summary
- ensure run_pipeline resets helper paths when `base_dir` changes

## Testing
- `black pipeline.py`
- `ruff check pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686420b524dc832c91d80b42d0ae0b5a