### PR TITLE
Ensure text filenames use sanitized DOIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The end-to-end processing steps are:
 ## Implemented Features
 - **PDF Ingestion**: Automated collection and logging of academic PDFs.
 - **Text Extraction**: Conversion of PDFs to structured, page-wise text files.
+  Extracted text files are renamed to sanitized DOIs so indexing and retrieval
+  use consistent identifiers.
 - **Metadata Extraction (Agent 1)**: Uses the OpenAI API to pull key metadata fields into JSON.
 - **Data Aggregation**: Collates individual metadata JSON files into a master dataset.
 - **Text Retrieval Helper**: Retrieves relevant snippets via the embedding index when available, falling back to keyword search.

--- a/agent1/metadata_extractor.py
+++ b/agent1/metadata_extractor.py
@@ -58,6 +58,14 @@ class MetadataExtractor:
         )
         out_path = META_DIR / f"{name}.json"
         out_path.write_bytes(orjson.dumps(metadata.model_dump()))
+
+        if text_path is not None:
+            new_text_path = text_path.with_name(f"{name}.json")
+            if new_text_path != text_path:
+                try:
+                    text_path.rename(new_text_path)
+                except FileExistsError:
+                    pass
         return out_path
 
     def extract(

--- a/tests/test_metadata_extractor.py
+++ b/tests/test_metadata_extractor.py
@@ -59,6 +59,20 @@ def test_extract_success(tmp_path, monkeypatch):
     assert client.calls == 1
 
 
+def test_text_file_renamed(tmp_path, monkeypatch):
+    from agent1.metadata_extractor import MetadataExtractor
+
+    text_path = create_text_file(tmp_path, "paper")
+    monkeypatch.setattr("agent1.metadata_extractor.META_DIR", tmp_path / "meta")
+    client = FakeClient([valid_data()])
+    extractor = MetadataExtractor(client=client)
+    result = extractor.extract(text_path, "Drug")
+    assert result is not None
+    renamed = text_path.with_name("10.1_abc.json")
+    assert renamed.exists()
+    assert not text_path.exists()
+
+
 def test_extract_retry(tmp_path, monkeypatch):
     from agent1.metadata_extractor import MetadataExtractor
 


### PR DESCRIPTION
## Summary
- rename extracted text files using sanitized DOIs
- explain identifier normalization in README
- test renaming behaviour

## Testing
- `ruff check agent1/metadata_extractor.py tests/test_metadata_extractor.py`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864501d3e64832ca9caa2f28ecaa28e