### PR TITLE
Add snippet validation test

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -113,3 +113,36 @@ def test_generate_narrative_cache(monkeypatch, tmp_path):
     pipeline.generate_narrative("drug", embed_model="m", retrieval_method="faiss")
 
     assert calls["count"] == 1
+
+
+def test_no_blank_snippets(monkeypatch, tmp_path):
+    from agent2 import openai_index as oi
+    from agent2 import retrieval
+
+    text_dir = tmp_path / "text"
+    text_dir.mkdir()
+    file_path = text_dir / "10.7_blank.json"
+    file_path.write_text('{"pages":[{"page":1,"text":"drug snippet"}]}')
+    index_path = tmp_path / "index.faiss"
+
+    monkeypatch.setattr(
+        oi, "embed_chunks", lambda chunks, model="m": [[0.1, 0.2] for _ in chunks]
+    )
+    oi.build_openai_index([file_path], index_path, model="m")
+
+    monkeypatch.setattr(retrieval, "TEXT_DIR", text_dir)
+    monkeypatch.setattr(retrieval, "INDEX_PATH", index_path)
+    monkeypatch.setattr("pipeline.OUTPUT_DIR", tmp_path / "out")
+    monkeypatch.setattr("aggregate.MASTER_PATH", tmp_path / "master.json")
+    records = [{"title": "T", "doi": "10.7/blank"}]
+    (tmp_path / "master.json").write_text(orjson.dumps(records).decode())
+
+    class CheckingNarrative(FakeNarrative):
+        def generate(self, metadata, snippets):
+            assert snippets, "no snippets returned"
+            assert all(s.strip() for s in snippets), "blank snippet detected"
+            return super().generate(metadata, snippets)
+
+    monkeypatch.setattr("pipeline.OpenAINarrative", lambda *a, **k: CheckingNarrative())
+
+    pipeline.generate_narrative("drug", embed_model="m", retrieval_method="faiss")


### PR DESCRIPTION
## Summary
- check that snippet retrieval never passes blank text to the narrative agent

## Testing
- `black .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645be9ad50832ca60f755142c21576