### PR TITLE
Save snippets before narrative generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ and embeddings default to `text-embedding-3-small`.
 - Individual metadata JSONs in `data/meta/`.
 - Aggregated metadata in `data/master.json`.
 - Generated narrative reviews in `outputs/`.
+- Retrieved snippets saved to `snippets.json` before the narrative step.
 - For instructions on processing a new drug, see `docs/HOW_TO_ADD_NEW_DRUG.md`.
 
 ## Cleaning Up Generated Data

--- a/agent2/synthesiser.py
+++ b/agent2/synthesiser.py
@@ -12,13 +12,15 @@ from agent2.openai_narrative import OpenAINarrative
 BASE_DIR = Path("data")
 MASTER_PATH = BASE_DIR / "master.json"
 OUTPUT_DIR = BASE_DIR / "outputs"
+SNIPPETS_PATH = BASE_DIR / "snippets.json"
 
 
 def set_base_dir(base_dir: Path) -> None:
-    global BASE_DIR, MASTER_PATH, OUTPUT_DIR
+    global BASE_DIR, MASTER_PATH, OUTPUT_DIR, SNIPPETS_PATH
     BASE_DIR = Path(base_dir)
     MASTER_PATH = BASE_DIR / "master.json"
     OUTPUT_DIR = BASE_DIR / "outputs"
+    SNIPPETS_PATH = BASE_DIR / "snippets.json"
 
 
 def load_master() -> List[Dict]:
@@ -56,6 +58,7 @@ def synthesise(drug: str) -> Path:
     if not records:
         raise ValueError(f"No studies found for {drug}")
     snippets = collect_snippets(records, drug)
+    SNIPPETS_PATH.write_bytes(orjson.dumps(snippets))
     generator = OpenAINarrative()
     narrative = generator.generate(records, snippets)
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)

--- a/pipeline.py
+++ b/pipeline.py
@@ -36,6 +36,8 @@ OUTPUT_DIR = DEFAULT_OUTPUT_DIR
 DEFAULT_META_DIR = meta_mod.META_DIR
 DEFAULT_MASTER_PATH = aggregate.MASTER_PATH
 DEFAULT_HISTORY_DIR = aggregate.HISTORY_DIR
+DEFAULT_SNIPPETS_PATH = Path("data/snippets.json")
+SNIPPETS_PATH = DEFAULT_SNIPPETS_PATH
 
 logger = get_logger("pipeline")
 
@@ -52,6 +54,7 @@ def make_dirs(base_dir: Path) -> SimpleNamespace:
         index=base / "index.faiss",
         master=base / "master.json",
         history=base / "master_history",
+        snippets=base / "snippets.json",
     )
 
 
@@ -121,6 +124,7 @@ def generate_narrative(
                     method=retrieval_method,
                 )
             )
+    SNIPPETS_PATH.write_bytes(orjson.dumps(snippets))
     generator = (
         OpenAINarrative(model=agent2_model) if agent2_model else OpenAINarrative()
     )
@@ -154,12 +158,14 @@ def run_pipeline(
 ) -> None:
     """Execute the full data processing pipeline."""
     dirs = make_dirs(base_dir)
-    global TEXT_DIR, OUTPUT_DIR
+    global TEXT_DIR, OUTPUT_DIR, SNIPPETS_PATH
     # Adjust helper module paths if they do not already point inside ``base_dir``.
     if not TEXT_DIR.resolve().is_relative_to(dirs.base):
         TEXT_DIR = dirs.text
     if not OUTPUT_DIR.resolve().is_relative_to(dirs.base):
         OUTPUT_DIR = dirs.outputs
+    if not SNIPPETS_PATH.resolve().is_relative_to(dirs.base):
+        SNIPPETS_PATH = dirs.snippets
     if not meta_mod.META_DIR.resolve().is_relative_to(dirs.base):
         meta_mod.META_DIR = dirs.meta
     if not aggregate.META_DIR.resolve().is_relative_to(dirs.base):

--- a/tests/agent2/test_synthesiser_cli.py
+++ b/tests/agent2/test_synthesiser_cli.py
@@ -44,6 +44,7 @@ def test_cli_success(monkeypatch, tmp_path: Path) -> None:
     out_dir = tmp_path / "out"
     monkeypatch.setattr(synthesiser, "MASTER_PATH", master)
     monkeypatch.setattr(synthesiser, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(synthesiser, "SNIPPETS_PATH", tmp_path / "snippets.json")
     monkeypatch.setattr(synthesiser, "OpenAINarrative", FakeNarrative)
     monkeypatch.setattr(synthesiser.retrieval, "get_snippets", lambda doi, kw: [f"s-{doi}"])  # type: ignore
 
@@ -52,6 +53,9 @@ def test_cli_success(monkeypatch, tmp_path: Path) -> None:
     out_file = out_dir / "review_DrugX.md"
     assert out_file.exists()
     assert out_file.read_text() == "# Review"
+    snippets_path = tmp_path / "snippets.json"
+    assert snippets_path.exists()
+    assert orjson.loads(snippets_path.read_bytes()) == ["s-10.1/a"]
 
 
 def test_no_data(monkeypatch, tmp_path: Path) -> None:
@@ -59,6 +63,7 @@ def test_no_data(monkeypatch, tmp_path: Path) -> None:
     out_dir = tmp_path / "out"
     monkeypatch.setattr(synthesiser, "MASTER_PATH", master)
     monkeypatch.setattr(synthesiser, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(synthesiser, "SNIPPETS_PATH", tmp_path / "snippets.json")
     monkeypatch.setattr(synthesiser, "OpenAINarrative", FakeNarrative)
 
     code = synthesiser.main(["--drug", "Missing"])
@@ -71,6 +76,7 @@ def test_empty_snippets(monkeypatch, tmp_path: Path) -> None:
     out_dir = tmp_path / "out"
     monkeypatch.setattr(synthesiser, "MASTER_PATH", master)
     monkeypatch.setattr(synthesiser, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(synthesiser, "SNIPPETS_PATH", tmp_path / "snippets.json")
     monkeypatch.setattr(synthesiser, "OpenAINarrative", FakeNarrative)
     monkeypatch.setattr(synthesiser.retrieval, "get_snippets", lambda doi, kw: [])  # type: ignore
 
@@ -79,3 +85,6 @@ def test_empty_snippets(monkeypatch, tmp_path: Path) -> None:
     out_file = out_dir / "review_DrugX.md"
     assert out_file.exists()
     assert out_file.read_text() == "# Review"
+    snippets_path = tmp_path / "snippets.json"
+    assert snippets_path.exists()
+    assert orjson.loads(snippets_path.read_bytes()) == []

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -79,3 +79,5 @@ def test_full_pipeline_cli(monkeypatch, tmp_path: Path) -> None:
 
     out_file = tmp_path / "outputs" / "review_TestDrug.md"
     assert out_file.exists()
+    snippets_path = tmp_path / "snippets.json"
+    assert snippets_path.exists()


### PR DESCRIPTION
## Summary
- persist text snippets to `snippets.json` before Agent2 generates the final narrative
- expose snippet file path through pipeline configuration
- test that the CLI and full pipeline create this snippet file
- document snippet output in README

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686469525360832c82e5135a21380848