### PR TITLE
Include outcome and QC fields in pipeline

### DIFF
--- a/schemas/metadata.py
+++ b/schemas/metadata.py
@@ -22,3 +22,5 @@ class PaperMetadata(BaseModel):
     targets: Optional[List[str]] = None
     p_threshold: Optional[str] = None
     ld_r2: Optional[str] = None
+    outcome: Optional[str] = None
+    additional_QC: Optional[str] = None

--- a/tests/agent1/test_agent1_metadata.py
+++ b/tests/agent1/test_agent1_metadata.py
@@ -58,6 +58,8 @@ def test_paper_metadata_validation():
         "targets": ["t"],
         "p_threshold": "1e-5",
         "ld_r2": "0.1",
+        "outcome": None,
+        "additional_QC": None,
     }
     meta = PaperMetadata(**data)
     assert meta.title == "T"

--- a/tests/test_metadata_extractor.py
+++ b/tests/test_metadata_extractor.py
@@ -42,6 +42,8 @@ def valid_data() -> dict:
         "targets": None,
         "p_threshold": None,
         "ld_r2": None,
+        "outcome": None,
+        "additional_QC": None,
     }
 
 

--- a/tests/test_openai_json_caller_live.py
+++ b/tests/test_openai_json_caller_live.py
@@ -36,6 +36,8 @@ def test_openai_json_caller_live():
         "targets",
         "p_threshold",
         "ld_r2",
+        "outcome",
+        "additional_QC",
     }
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -32,6 +32,8 @@ def valid_metadata() -> dict:
         "targets": None,
         "p_threshold": None,
         "ld_r2": None,
+        "outcome": None,
+        "additional_QC": None,
     }
 
 

--- a/tests/test_schema_drift.py
+++ b/tests/test_schema_drift.py
@@ -19,6 +19,8 @@ EXPECTED_KEYS = {
     "targets",
     "p_threshold",
     "ld_r2",
+    "outcome",
+    "additional_QC",
 }
 
 

--- a/tests/test_z_pipeline.py
+++ b/tests/test_z_pipeline.py
@@ -36,6 +36,8 @@ def valid_metadata() -> dict:
         "targets": None,
         "p_threshold": None,
         "ld_r2": None,
+        "outcome": None,
+        "additional_QC": None,
     }
 
 


### PR DESCRIPTION
## Summary
- extend `PaperMetadata` schema with new fields `outcome` and `additional_QC`
- update unit tests for the schema changes

## Testing
- `black . --quiet`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a37405fc832cae6703d0d79f318e