### PR TITLE
Refine batch mode to split by tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,9 @@ python run_pipeline.py \
 ```
 If not specified, Agent 1 and Agent 2 default to `gpt-4o-2024-05-13`
 and embeddings default to `text-embedding-3-small`. Passing `--batch`
-writes `agent1_batch.jsonl` to the chosen base directory and exits
-without contacting the API.
+writes one or more files named `<drug>_batch_<n>.jsonl` (each capped at
+40,000 tokens) to the chosen base directory and exits without
+contacting the API.
 
 ## Output
 - Individual metadata JSONs in `data/meta/`.

--- a/docs/HOW_TO_ADD_NEW_DRUG.md
+++ b/docs/HOW_TO_ADD_NEW_DRUG.md
@@ -16,7 +16,7 @@ python run_pipeline.py --pdf_dir data/new_pdfs --drug <your_drug_name> \
 
 Ensure the OpenAI API key is available via ``OPENAI_API_KEY`` or the secret file ``/run/secrets/openai_api_key`` and that you've installed the dependencies from ``requirements.txt``.
 
-This command ingests the PDFs, extracts text, gathers metadata, and generates a narrative review. With `--batch`, the pipeline writes `agent1_batch.jsonl` and exits before contacting the API.
+This command ingests the PDFs, extracts text, gathers metadata, and generates a narrative review. With `--batch`, the pipeline writes batch files named `<your_drug_name>_batch_<n>.jsonl` (each under 40,000 tokens) and exits before contacting the API.
 
 ## Step 3: Check Outputs
 - The review will be written to `outputs/review_<your_drug_name>.md`.


### PR DESCRIPTION
## Summary
- enforce batch file token cap
- name batch files `<drug>_batch_<n>.jsonl`
- document new batching behaviour
- test batch splitting logic

## Testing
- `ruff check .`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d06d5d68832cb772caf4df6aab9c