### PR TITLE
Implement Agent3 conflict validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The end-to-end processing steps are:
 - **Embedding Indexing**: Builds a FAISS vector store from extracted text for semantic snippet retrieval.
 - **Embedding-based Retrieval**: Searches the FAISS index for semantically similar text chunks.
 - **Narrative Review Generation (Agent 2)**: Generates peer-review style summaries using `agent2/openai_narrative.py`.
-- **Validator Framework (Agent 3)**: Placeholder module for future pipeline checks.
+- **Validator Framework (Agent 3)**: Checks for logical conflicts between metadata fields using the OpenAI Assistants API.
 
 ## Script Overview
 Below is a brief description of the main scripts and where their outputs are written.

--- a/agent3/openai_validator.py
+++ b/agent3/openai_validator.py
@@ -1,4 +1,71 @@
-class Agent3Validator:
-    """Placeholder validator for Agent 3."""
+from __future__ import annotations
 
-    pass
+from pathlib import Path
+import time
+
+from openai import OpenAI
+
+from utils.logger import get_logger
+from utils.secrets import get_openai_api_key
+
+PROMPT_PATH = Path(__file__).resolve().parents[1] / "prompts" / "agent3_system.txt"
+
+logger = get_logger(__name__)
+
+_client: OpenAI | None = None
+_assistant_id: str | None = None
+_assistant_model: str | None = None
+
+
+def _get_client() -> OpenAI:
+    global _client
+    if _client is None:
+        _client = OpenAI(api_key=get_openai_api_key())
+    return _client
+
+
+def _init_assistant(model: str) -> None:
+    global _assistant_id, _assistant_model
+    if _assistant_id is None or _assistant_model != model:
+        with PROMPT_PATH.open("r", encoding="utf-8") as f:
+            prompt = f.read()
+        client = _get_client()
+        assistant = client.beta.assistants.create(instructions=prompt, model=model)
+        _assistant_id = assistant.id
+        _assistant_model = model
+
+
+def _wait_for_run(client: OpenAI, thread_id: str, run_id: str) -> None:
+    while True:
+        run = client.beta.threads.runs.retrieve(thread_id=thread_id, run_id=run_id)
+        status = run.status
+        if status == "completed":
+            return
+        if status in {"failed", "cancelled", "expired"}:
+            raise RuntimeError(f"Run {run_id} ended with status {status}")
+        time.sleep(0.25)
+
+
+# Create assistant at import using default model
+_init_assistant("gpt-4o")
+
+
+def is_conflict(
+    value1: str, value2: str, field_name: str, model: str = "gpt-4o"
+) -> bool:
+    """Return ``True`` if the two values appear logically inconsistent."""
+    _init_assistant(model)
+    client = _get_client()
+    user = f"Field: {field_name}\nValue 1: {value1}\nValue 2: {value2}"
+    thread = client.beta.threads.create(messages=[{"role": "user", "content": user}])
+    run = client.beta.threads.runs.create(
+        thread_id=thread.id, assistant_id=_assistant_id
+    )
+    _wait_for_run(client, thread.id, run.id)
+    messages = client.beta.threads.messages.list(thread_id=thread.id)
+    answer = messages.data[0].content[0].text.value.strip().lower()
+    if answer.startswith("yes"):
+        return True
+    if answer.startswith("no"):
+        return False
+    raise RuntimeError(f"Unexpected reply: {answer}")

--- a/prompts/agent3_system.txt
+++ b/prompts/agent3_system.txt
@@ -1,1 +1,1 @@
-System prompt placeholder for agent3.
+You check whether two extracted values conflict. Reply with "Yes" if they contradict or "No" if they could both be correct. Only answer with "Yes" or "No".

--- a/tests/test_openai_validator.py
+++ b/tests/test_openai_validator.py
@@ -1,0 +1,94 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+# Fake OpenAI module for assistants API
+fake_openai = types.ModuleType("openai")
+
+
+class FakeAssistants:
+    def __init__(self) -> None:
+        self.create_calls = []
+
+    def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return types.SimpleNamespace(id="assist-1")
+
+
+class FakeRuns:
+    def __init__(self) -> None:
+        self.create_calls = []
+        self.retrieve_calls = []
+
+    def create(self, thread_id, assistant_id, **kwargs):
+        self.create_calls.append({"thread_id": thread_id, "assistant_id": assistant_id})
+        return types.SimpleNamespace(id="run-1", status="completed")
+
+    def retrieve(self, thread_id, run_id):
+        self.retrieve_calls.append({"thread_id": thread_id, "run_id": run_id})
+        return types.SimpleNamespace(id=run_id, status="completed")
+
+
+class FakeMessages:
+    def __init__(self, parent) -> None:
+        self.parent = parent
+        self.list_calls = []
+
+    def list(self, thread_id):
+        self.list_calls.append({"thread_id": thread_id})
+        text = self.parent.responses.pop(0)
+        msg = types.SimpleNamespace(
+            content=[types.SimpleNamespace(text=types.SimpleNamespace(value=text))]
+        )
+        return types.SimpleNamespace(data=[msg])
+
+
+class FakeThreads:
+    def __init__(self) -> None:
+        self.create_calls = []
+        self.runs = FakeRuns()
+        self.messages = FakeMessages(self)
+        self.responses = []
+
+    def create(self, messages=None):
+        self.create_calls.append(messages)
+        return types.SimpleNamespace(id=f"thread-{len(self.create_calls)}")
+
+
+fake_assistants = FakeAssistants()
+fake_threads = FakeThreads()
+fake_client = types.SimpleNamespace(
+    beta=types.SimpleNamespace(assistants=fake_assistants, threads=fake_threads)
+)
+fake_openai.OpenAI = lambda api_key=None: fake_client
+
+real_openai = sys.modules.get("openai")
+
+
+@pytest.fixture(autouse=True)
+def fake_module(monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    import agent3.openai_validator as ov
+
+    prompt = tmp_path / "agent3_system.txt"
+    prompt.write_text("Prompt")
+    monkeypatch.setattr(ov, "PROMPT_PATH", prompt)
+    monkeypatch.setattr(ov, "get_openai_api_key", lambda: "key")
+    fake_assistants.create_calls.clear()
+    importlib.reload(ov)
+    yield ov
+    if real_openai is not None:
+        monkeypatch.setitem(sys.modules, "openai", real_openai)
+    else:
+        monkeypatch.delitem(sys.modules, "openai", raising=False)
+    sys.modules.pop("agent3.openai_validator", None)
+
+
+def test_reuse_assistant(fake_module):
+    fake_threads.responses = ["Yes", "No"]
+    assert fake_module.is_conflict("A", "B", "title") is True
+    assert fake_module.is_conflict("A", "A", "title") is False
+    assert len(fake_assistants.create_calls) == 1


### PR DESCRIPTION
## Summary
- flesh out Agent 3 validator using OpenAI Assistants
- add concise prompt for Agent 3
- update project overview in README
- test that the assistant is reused and responses interpreted

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5c3a1aa0832ca9c638456a99df55