### PR TITLE
Add field-level master diff utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Below is a brief description of the main scripts and where their outputs are wri
   remove files in `data/pdfs/` as well.
 - `utils/master_loader.py` loads `master.json` files and verifies that two
   versions contain the same set of record keys.
+- `utils/master_diff.py` compares two masters and reports field-level
+  differences for each record.
 
 ## Features Under Development
 None at this time.

--- a/tests/utils/test_master_diff.py
+++ b/tests/utils/test_master_diff.py
@@ -1,0 +1,26 @@
+from utils.master_diff import generate_diffs
+
+
+def test_all_match() -> None:
+    m1 = [{"doi": "1", "title": "A"}]
+    m2 = [{"doi": "1", "title": "A"}]
+    diffs = generate_diffs(m1, m2)
+    assert list(diffs.keys()) == [("1", "doi"), ("1", "title")]
+    assert all(res.status == "match" for res in diffs.values())
+
+
+def test_all_diff() -> None:
+    m1 = [{"doi": "1", "title": "A"}]
+    m2 = [{"doi": "1", "title": "B"}]
+    diffs = generate_diffs(m1, m2)
+    assert diffs[("1", "title")].status == "diff"
+    assert diffs[("1", "title")].value1 == "A"
+    assert diffs[("1", "title")].value2 == "B"
+
+
+def test_mixed_fields() -> None:
+    m1 = [{"doi": "1", "title": "A", "extra": 1}]
+    m2 = [{"doi": "1", "title": "A", "extra": 2}]
+    diffs = generate_diffs(m1, m2)
+    assert diffs[("1", "title")].status == "match"
+    assert diffs[("1", "extra")].status == "diff"

--- a/utils/master_diff.py
+++ b/utils/master_diff.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Tuple
+
+from utils.master_loader import ensure_compat
+
+
+@dataclass
+class DiffResult:
+    value1: Any
+    value2: Any
+    status: str
+
+
+def generate_diffs(
+    master1: list[dict], master2: list[dict], key: str = "doi"
+) -> Dict[Tuple[str, str], DiffResult]:
+    """Return field-level diffs between ``master1`` and ``master2``.
+
+    ``master1`` and ``master2`` must contain the same set of records for
+    ``key``. Each pair of values is compared and stored under a tuple of the
+    record key and field name.
+    """
+    ensure_compat(master1, master2, key)
+
+    recs1 = {rec.get(key): rec for rec in master1}
+    recs2 = {rec.get(key): rec for rec in master2}
+
+    diffs: Dict[Tuple[str, str], DiffResult] = {}
+    for rec_key in recs1:
+        r1 = recs1[rec_key]
+        r2 = recs2[rec_key]
+        fields = set(r1) | set(r2)
+        for field in fields:
+            v1 = r1.get(field)
+            v2 = r2.get(field)
+            status = "match" if v1 == v2 else "diff"
+            diffs[(rec_key, field)] = DiffResult(v1, v2, status)
+    return diffs


### PR DESCRIPTION
## Summary
- implement `utils.master_diff.generate_diffs` returning a map of field-level comparisons
- add unit tests for the diff generator
- document new helper in README

## Testing
- `ruff check --fix utils/master_diff.py tests/utils/test_master_diff.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5ecc5f7c832c84ccc295a30130a3