### PR TITLE
Implement master comparison CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Below is a brief description of the main scripts and where their outputs are wri
   versions contain the same set of record keys.
 - `utils/master_diff.py` compares two masters and reports field-level
   differences for each record.
+- `agent3/compare_masters.py` detects conflicts between two master JSON files using Agent 3.
 
 ## Features Under Development
 None at this time.

--- a/agent3/compare_masters.py
+++ b/agent3/compare_masters.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from datetime import datetime
+from pathlib import Path
+import orjson
+
+from utils.logger import get_logger
+from utils.master_loader import load_master
+from utils.master_diff import generate_diffs
+from agent3.openai_validator import is_conflict
+
+
+OUT_DIR = Path("data/validation")
+logger = get_logger(__name__)
+
+
+def compare(master1_path: Path, master2_path: Path, out_path: Path) -> list[dict]:
+    """Compare *master1_path* and *master2_path* and write results to *out_path*."""
+    m1 = load_master(master1_path)
+    m2 = load_master(master2_path)
+    diffs = generate_diffs(m1, m2)
+    results: list[dict] = []
+    for (key, field), diff in diffs.items():
+        if diff.status != "diff":
+            continue
+        conflict = is_conflict(str(diff.value1), str(diff.value2), field)
+        results.append(
+            {
+                "key": key,
+                "field": field,
+                "v1": diff.value1,
+                "v2": diff.value2,
+                "conflict": conflict,
+            }
+        )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(orjson.dumps(results, option=orjson.OPT_INDENT_2))
+    logger.info(
+        "Compared %s fields, %s conflicts found",
+        len(results),
+        sum(1 for r in results if r["conflict"]),
+    )
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = ArgumentParser(description="Detect conflicts between two master files.")
+    parser.add_argument("master_v1", help="Path to first master JSON")
+    parser.add_argument("master_v2", help="Path to second master JSON")
+    parser.add_argument("--out", help="Output JSON path")
+    args = parser.parse_args(argv)
+
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        out_path = OUT_DIR / f"comparison_{timestamp}.json"
+
+    compare(Path(args.master_v1), Path(args.master_v2), out_path)
+    print(f"Results written to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent3/test_compare_masters.py
+++ b/tests/agent3/test_compare_masters.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+import orjson
+
+# Stub out openai_validator before importing module
+fake_validator = types.ModuleType("agent3.openai_validator")
+fake_validator.is_conflict = lambda v1, v2, field: True
+sys.modules["agent3.openai_validator"] = fake_validator
+
+from agent3 import compare_masters  # noqa: E402
+
+sys.modules.pop("agent3.openai_validator")
+
+
+def create_master(path: Path, records: list[dict]) -> None:
+    path.write_bytes(orjson.dumps(records))
+
+
+def test_compare_cli(tmp_path: Path):
+    m1_path = tmp_path / "m1.json"
+    m2_path = tmp_path / "m2.json"
+    create_master(m1_path, [{"doi": "1", "title": "A"}])
+    create_master(m2_path, [{"doi": "1", "title": "B"}])
+
+    out_path = tmp_path / "out.json"
+    code = compare_masters.main([str(m1_path), str(m2_path), "--out", str(out_path)])
+    assert code == 0
+    data = orjson.loads(out_path.read_bytes())
+    assert data == [
+        {"key": "1", "field": "title", "v1": "A", "v2": "B", "conflict": True}
+    ]

--- a/utils/master_diff.py
+++ b/utils/master_diff.py
@@ -31,7 +31,7 @@ def generate_diffs(
     for rec_key in recs1:
         r1 = recs1[rec_key]
         r2 = recs2[rec_key]
-        fields = set(r1) | set(r2)
+        fields = sorted(set(r1) | set(r2))
         for field in fields:
             v1 = r1.get(field)
             v2 = r2.get(field)


### PR DESCRIPTION
## Summary
- add CLI agent3.compare_masters to detect conflicts between master files
- ensure deterministic ordering of diffs in utils.master_diff
- document the new script in README
- test CLI behaviour

## Testing
- `ruff check agent3/compare_masters.py tests/agent3/test_compare_masters.py utils/master_diff.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6015c01c832c9d4b1150fc7dfde7