### PR TITLE
Implement master validation merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Below is a brief description of the main scripts and where their outputs are wri
 - `agent3/compare_masters.py` detects conflicts between two master JSON files using Agent 3.
 - `cli/resolve_conflicts.py` interactively resolves conflicting fields recorded
   in a comparison JSON.
+- `agent3/write_validated_master.py` merges two master files using a resolution
+  JSON and writes a validated master plus a metadata summary.
 
 ## Features Under Development
 None at this time.

--- a/agent3/write_validated_master.py
+++ b/agent3/write_validated_master.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from datetime import datetime
+from pathlib import Path
+import orjson
+
+from utils.master_loader import load_master, ensure_compat
+from utils.master_diff import generate_diffs
+
+OUT_DIR = Path("data/validation")
+
+
+def merge_masters(
+    m1_path: Path, m2_path: Path, res_path: Path, out_dir: Path
+) -> tuple[Path, Path]:
+    m1 = load_master(m1_path)
+    m2 = load_master(m2_path)
+    ensure_compat(m1, m2)
+    diffs = generate_diffs(m1, m2)
+
+    resolutions = orjson.loads(res_path.read_bytes())
+    res_map = {(r["key"], r["field"]): r for r in resolutions}
+
+    records = []
+    recs1 = {rec.get("doi"): rec for rec in m1}
+    recs2 = {rec.get("doi"): rec for rec in m2}
+    for key in sorted(recs1):
+        r1 = recs1[key]
+        r2 = recs2[key]
+        fields = sorted(set(r1) | set(r2))
+        merged: dict = {}
+        for field in fields:
+            if (key, field) in res_map:
+                value = res_map[(key, field)]["resolved_value"]
+            else:
+                value = r1.get(field)
+            if value is not None:
+                merged[field] = value
+        records.append(merged)
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    master_path = out_dir / f"master_validated_{timestamp}.json"
+    meta_path = out_dir / f"master_validated_meta_{timestamp}.json"
+    master_path.write_bytes(orjson.dumps(records, option=orjson.OPT_INDENT_2))
+
+    total_fields = len(diffs)
+    matches = sum(1 for d in diffs.values() if d.status == "match")
+    meta = {
+        "total_fields": total_fields,
+        "matches": matches,
+        "conflicts": len(resolutions),
+        "v1_chosen": sum(r["resolution_type"] == "v1" for r in resolutions),
+        "v2_chosen": sum(r["resolution_type"] == "v2" for r in resolutions),
+        "manual_edits": sum(r["resolution_type"] == "manual" for r in resolutions),
+    }
+    meta_path.write_bytes(orjson.dumps(meta, option=orjson.OPT_INDENT_2))
+
+    return master_path, meta_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = ArgumentParser(description="Write validated master dataset")
+    parser.add_argument("master_v1", help="Path to master_v1.json")
+    parser.add_argument("master_v2", help="Path to master_v2.json")
+    parser.add_argument("resolution", help="Path to resolution JSON")
+    parser.add_argument("--out_dir", default=str(OUT_DIR), help="Output directory")
+    args = parser.parse_args(argv)
+
+    merge_masters(
+        Path(args.master_v1),
+        Path(args.master_v2),
+        Path(args.resolution),
+        Path(args.out_dir),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent3/test_write_validated_master.py
+++ b/tests/agent3/test_write_validated_master.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import orjson
+
+from agent3 import write_validated_master
+
+
+def create_master(path: Path, records: list[dict]) -> None:
+    path.write_bytes(orjson.dumps(records))
+
+
+def test_cli(tmp_path: Path, monkeypatch) -> None:
+    m1 = [
+        {"doi": "1", "title": "A", "year": 2023},
+        {"doi": "2", "title": "B", "year": 2020},
+    ]
+    m2 = [
+        {"doi": "1", "title": "A2", "year": 2023},
+        {"doi": "2", "title": "B", "year": 2021},
+    ]
+    m1_path = tmp_path / "m1.json"
+    m2_path = tmp_path / "m2.json"
+    create_master(m1_path, m1)
+    create_master(m2_path, m2)
+
+    resolution = [
+        {"key": "1", "field": "title", "resolved_value": "A2", "resolution_type": "v2"},
+        {"key": "2", "field": "year", "resolved_value": 2021, "resolution_type": "v2"},
+    ]
+    res_path = tmp_path / "res.json"
+    res_path.write_bytes(orjson.dumps(resolution))
+
+    out_dir = tmp_path / "out"
+
+    class DummyDT:
+        @classmethod
+        def utcnow(cls) -> datetime:
+            return datetime(2024, 1, 2, 3, 4, 5)
+
+    monkeypatch.setattr(write_validated_master, "datetime", DummyDT)
+
+    code = write_validated_master.main(
+        [
+            str(m1_path),
+            str(m2_path),
+            str(res_path),
+            "--out_dir",
+            str(out_dir),
+        ]
+    )
+    assert code == 0
+
+    master_path = out_dir / "master_validated_20240102_030405.json"
+    meta_path = out_dir / "master_validated_meta_20240102_030405.json"
+
+    data = orjson.loads(master_path.read_bytes())
+    assert data == [
+        {"doi": "1", "title": "A2", "year": 2023},
+        {"doi": "2", "title": "B", "year": 2021},
+    ]
+
+    meta = orjson.loads(meta_path.read_bytes())
+    assert meta == {
+        "total_fields": 6,
+        "matches": 4,
+        "conflicts": 2,
+        "v1_chosen": 0,
+        "v2_chosen": 2,
+        "manual_edits": 0,
+    }


### PR DESCRIPTION
## Summary
- add `agent3/write_validated_master.py` to merge two masters using a resolution file
- document the script in the README
- test the CLI behaviour for creating validated masters

## Testing
- `black .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d6c769710832cbb53ae9616ec94de