### PR TITLE
Add tests for master utilities

### DIFF
--- a/tests/fixtures/masters/master_a.json
+++ b/tests/fixtures/masters/master_a.json
@@ -1,0 +1,4 @@
+[
+  {"doi": "a", "title": "First", "score": 1.2345},
+  {"doi": "b", "title": "Second", "score": 2.0}
+]

--- a/tests/fixtures/masters/master_b.json
+++ b/tests/fixtures/masters/master_b.json
@@ -1,0 +1,4 @@
+[
+  {"doi": "a", "title": "First", "score": 1.2346},
+  {"doi": "b", "title": "Second changed", "score": 2.0}
+]

--- a/tests/utils/test_master_diff.py
+++ b/tests/utils/test_master_diff.py
@@ -1,4 +1,15 @@
+from pathlib import Path
+
+import orjson
+
 from utils.master_diff import generate_diffs
+
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "masters"
+
+
+def load_json(name: str) -> list[dict]:
+    return orjson.loads((FIXTURES / name).read_bytes())
 
 
 def test_all_match() -> None:
@@ -24,3 +35,27 @@ def test_mixed_fields() -> None:
     diffs = generate_diffs(m1, m2)
     assert diffs[("1", "title")].status == "match"
     assert diffs[("1", "extra")].status == "diff"
+
+
+def test_fixture_all_match() -> None:
+    m1 = load_json("master_a.json")
+    m2 = load_json("master_a.json")
+    diffs = generate_diffs(m1, m2)
+    assert all(d.status == "match" for d in diffs.values())
+
+
+def test_fixture_all_diff() -> None:
+    m1 = load_json("master_a.json")
+    m2 = load_json("master_b.json")
+    diffs = generate_diffs(m1, m2)
+    statuses = {d.status for d in diffs.values()}
+    assert statuses == {"match", "diff"}
+    assert diffs[("b", "title")].status == "diff"
+
+
+def test_numeric_rounding_edge() -> None:
+    m1 = [{"doi": "1", "val": 1.2345}]
+    m2 = [{"doi": "1", "val": 1.2346}]
+    diff = generate_diffs(m1, m2)[("1", "val")]
+    assert diff.status == "diff"
+    assert round(diff.value1, 2) == round(diff.value2, 2)

--- a/tests/utils/test_master_loader.py
+++ b/tests/utils/test_master_loader.py
@@ -3,7 +3,10 @@ from pathlib import Path
 import orjson
 import pytest
 
-from utils.master_loader import load_master, ensure_compat
+from utils.master_loader import ensure_compat, load_master
+
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "masters"
 
 
 def create_master(path: Path, records: list[dict]) -> None:
@@ -42,3 +45,27 @@ def test_ensure_compat_key_mismatch() -> None:
     list2 = [{"doi": "1"}, {"doi": "3"}]
     with pytest.raises(ValueError):
         ensure_compat(list1, list2)
+
+
+def test_load_master_fixture() -> None:
+    """Load records from bundled fixture file."""
+    path = FIXTURES / "master_a.json"
+    records = load_master(path)
+    assert isinstance(records, list)
+    assert records[0]["doi"] == "a"
+
+
+def test_incompatible_length_using_fixtures() -> None:
+    """Different number of records triggers error."""
+    m1 = load_master(FIXTURES / "master_a.json")
+    m2 = m1 + [{"doi": "c"}]
+    with pytest.raises(ValueError):
+        ensure_compat(m1, m2)
+
+
+def test_missing_primary_key() -> None:
+    """A record missing the primary key fails compatibility check."""
+    m1 = load_master(FIXTURES / "master_a.json")
+    m2 = [{"title": "First"}, *m1[1:]]
+    with pytest.raises(ValueError):
+        ensure_compat(m1, m2)


### PR DESCRIPTION
## Summary
- add fixtures for master loader tests
- expand master_loader and generate_diffs unit tests
- ensure coverage over 90%

## Testing
- `pytest --cov=utils.master_loader --cov=utils.master_diff tests/utils/test_master_loader.py tests/utils/test_master_diff.py -q`
- `pytest --cov -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6e1d281c832cb181e331bba4414b