### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'outputs/*.md'
+      - 'README.md'
+      - 'docs/**/*.md'
 
 jobs:
   markdown-lint:
@@ -15,4 +17,4 @@ jobs:
         with:
           node-version: '18'
       - run: npm install -g markdownlint-cli
-      - run: markdownlint outputs/*.md
+      - run: markdownlint outputs/*.md README.md docs/**/*.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
-      - name: Run Schema Drift Test
+          pip install pytest pytest-cov
+      - name: Run Test Suite
         env:
           PYTHONPATH: ${{ github.workspace }}
-        run: python -m pytest tests/test_schema_drift.py
+        run: pytest --cov=. --cov-report=xml --cov-report=term --cov-fail-under=85

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+Thank you for considering a contribution! This project uses **Black**, **Ruff** and **pytest** with coverage.
+
+Before submitting a pull request:
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   pip install pytest pytest-cov
+   ```
+2. Format and lint the code:
+   ```bash
+   black .
+   ruff check .
+   ```
+3. Run the test suite with coverage (minimum 85% required):
+   ```bash
+   pytest --cov=. --cov-report=term --cov-fail-under=85
+   ```
+
+CI runs the same commands automatically.

--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ extraction scripts simply produce output files and do not currently log.
 Contributions are welcome! Fork the repository and submit a pull request with improvements or new features.
 
 ## Continuous Integration
-A GitHub Actions workflow automatically lints Markdown files in the `outputs/` directory on pull requests to the `main` branch.
-Another workflow runs a schema drift unit test to ensure that `PaperMetadata` does not change unexpectedly.
+A GitHub Actions workflow lints Markdown files (including `README.md`) and runs the full test suite on every pull request.
+Tests must maintain at least **85%** coverage or the build fails.
 
 ## API Cost Estimation
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import socket
 
 import pytest
 
@@ -11,3 +12,13 @@ import utils.secrets
 def global_openai_key(monkeypatch):
     monkeypatch.setattr(utils.secrets, "get_openai_api_key", lambda: "key")
     monkeypatch.setenv("OPENAI_API_KEY", "key")
+
+
+@pytest.fixture(autouse=True)
+def no_network_calls(monkeypatch):
+    """Fail tests that attempt real network access."""
+
+    def guard(*_args, **_kwargs):
+        raise RuntimeError("Network access blocked during tests")
+
+    monkeypatch.setattr(socket.socket, "connect", guard)


### PR DESCRIPTION
## Summary
- run entire test suite with coverage
- lint README and docs in markdown workflow
- block network calls in tests
- document local workflow commands

## Testing
- `black .`
- `ruff check .`
- `pytest --cov=. --cov-report=term --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_686d8bb85c4c832ca8a91fcfa57cbf4b