### PR TITLE
Improve master validation tests

### DIFF
--- a/tests/agent3/test_compare_masters.py
+++ b/tests/agent3/test_compare_masters.py
@@ -4,6 +4,7 @@ import sys
 import types
 from pathlib import Path
 import orjson
+import pytest
 
 # Stub out openai_validator before importing module
 fake_validator = types.ModuleType("agent3.openai_validator")
@@ -32,3 +33,36 @@ def test_compare_cli(tmp_path: Path):
     assert data == [
         {"key": "1", "field": "title", "v1": "A", "v2": "B", "conflict": True}
     ]
+
+
+def test_compare_skips_matching_fields(tmp_path: Path, monkeypatch) -> None:
+    m1_path = tmp_path / "m1.json"
+    m2_path = tmp_path / "m2.json"
+    create_master(m1_path, [{"doi": "1", "title": "A"}])
+    create_master(m2_path, [{"doi": "1", "title": "A"}])
+
+    called = False
+
+    def fake_conflict(v1: str, v2: str, field: str) -> bool:
+        nonlocal called
+        called = True
+        return True
+
+    monkeypatch.setattr(compare_masters, "is_conflict", fake_conflict)
+
+    out_path = tmp_path / "out.json"
+    results = compare_masters.compare(m1_path, m2_path, out_path)
+    assert results == []
+    assert out_path.read_text() == "[]"
+    assert called is False
+
+
+def test_compare_incompatible_masters(tmp_path: Path) -> None:
+    m1_path = tmp_path / "m1.json"
+    m2_path = tmp_path / "m2.json"
+    create_master(m1_path, [{"doi": "1", "title": "A"}])
+    create_master(m2_path, [{"doi": "2", "title": "B"}])
+
+    out_path = tmp_path / "out.json"
+    with pytest.raises(ValueError):
+        compare_masters.compare(m1_path, m2_path, out_path)

--- a/tests/agent3/test_write_validated_master.py
+++ b/tests/agent3/test_write_validated_master.py
@@ -70,3 +70,83 @@ def test_cli(tmp_path: Path, monkeypatch) -> None:
         "v2_chosen": 2,
         "manual_edits": 0,
     }
+
+
+class DummyDT:
+    @classmethod
+    def utcnow(cls) -> datetime:
+        return datetime(2024, 1, 2, 3, 4, 5)
+
+
+def test_merge_defaults_to_v1(tmp_path: Path, monkeypatch) -> None:
+    m1 = [{"doi": "1", "title": "A", "year": 2020}]
+    m2 = [{"doi": "1", "title": "B", "year": 2021}]
+    m1_path = tmp_path / "m1.json"
+    m2_path = tmp_path / "m2.json"
+    create_master(m1_path, m1)
+    create_master(m2_path, m2)
+
+    res_path = tmp_path / "res.json"
+    res_path.write_bytes(b"[]")
+
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(write_validated_master, "datetime", DummyDT)
+    master_path, meta_path = write_validated_master.merge_masters(
+        m1_path, m2_path, res_path, out_dir
+    )
+
+    data = orjson.loads(master_path.read_bytes())
+    assert data == [{"doi": "1", "title": "A", "year": 2020}]
+    meta = orjson.loads(meta_path.read_bytes())
+    assert meta == {
+        "total_fields": 3,
+        "matches": 1,
+        "conflicts": 0,
+        "v1_chosen": 0,
+        "v2_chosen": 0,
+        "manual_edits": 0,
+    }
+
+
+def test_merge_manual_resolution(tmp_path: Path, monkeypatch) -> None:
+    m1 = [{"doi": "1", "title": "A", "year": 2020}]
+    m2 = [{"doi": "1", "title": "B", "year": 2021}]
+    m1_path = tmp_path / "m1.json"
+    m2_path = tmp_path / "m2.json"
+    create_master(m1_path, m1)
+    create_master(m2_path, m2)
+
+    resolution = [
+        {
+            "key": "1",
+            "field": "title",
+            "resolved_value": "B",
+            "resolution_type": "v2",
+        },
+        {
+            "key": "1",
+            "field": "year",
+            "resolved_value": 2020,
+            "resolution_type": "manual",
+        },
+    ]
+    res_path = tmp_path / "res.json"
+    res_path.write_bytes(orjson.dumps(resolution))
+
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(write_validated_master, "datetime", DummyDT)
+    master_path, meta_path = write_validated_master.merge_masters(
+        m1_path, m2_path, res_path, out_dir
+    )
+
+    data = orjson.loads(master_path.read_bytes())
+    assert data == [{"doi": "1", "title": "B", "year": 2020}]
+    meta = orjson.loads(meta_path.read_bytes())
+    assert meta == {
+        "total_fields": 3,
+        "matches": 1,
+        "conflicts": 2,
+        "v1_chosen": 0,
+        "v2_chosen": 1,
+        "manual_edits": 1,
+    }


### PR DESCRIPTION
## Summary
- extend `test_compare_masters` to cover skipped fields and incompatible masters
- add tests for `merge_masters` handling default and manual resolutions

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7cc1bf94832ca4f98a6228c70d47