### PR TITLE
Implement fuzzy title matching for master comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Below is a brief description of the main scripts and where their outputs are wri
 
 Use this workflow to consolidate two versions of `master.json`.
 
+Records are now paired on title similarity (`token_set_ratio` ≥ 90 %). DOI is used only as an exact match or as a tie-breaker when multiple titles score ≥ 90 %.
+
 1. **Detect conflicts**
 
    ```bash

--- a/agent3/compare_masters.py
+++ b/agent3/compare_masters.py
@@ -7,7 +7,7 @@ import orjson
 
 from utils.logger import get_logger
 from utils.master_loader import load_master
-from utils.master_diff import generate_diffs
+from agent3.json_matcher import fuzzy_match_titles
 from agent3.openai_validator import is_conflict
 
 
@@ -15,25 +15,65 @@ OUT_DIR = Path("data/validation")
 logger = get_logger(__name__)
 
 
+def _pair_records(master1: list[dict], master2: list[dict]) -> list[tuple[dict, dict]]:
+    pairs: list[tuple[dict, dict]] = []
+    remaining = list(master2)
+    for rec1 in master1:
+        doi1 = rec1.get("doi")
+        title1 = rec1.get("title", "")
+        match_idx: int | None = None
+        if doi1:
+            for i, rec2 in enumerate(remaining):
+                if rec2.get("doi") == doi1:
+                    match_idx = i
+                    break
+        if match_idx is None:
+            candidates: list[tuple[int, int]] = []
+            for i, rec2 in enumerate(remaining):
+                title2 = rec2.get("title", "")
+                score = fuzzy_match_titles(title1, title2)
+                if score is not None:
+                    candidates.append((score, i))
+            if candidates:
+                doi_candidates = [
+                    c for c in candidates if doi1 and remaining[c[1]].get("doi") == doi1
+                ]
+                if doi_candidates:
+                    match_idx = doi_candidates[0][1]
+                else:
+                    match_idx = max(candidates, key=lambda t: t[0])[1]
+        if match_idx is not None:
+            rec2 = remaining.pop(match_idx)
+            pairs.append((rec1, rec2))
+        else:
+            logger.warning("No match found for record %s", doi1 or title1)
+    return pairs
+
+
 def compare(master1_path: Path, master2_path: Path, out_path: Path) -> list[dict]:
     """Compare *master1_path* and *master2_path* and write results to *out_path*."""
     m1 = load_master(master1_path)
     m2 = load_master(master2_path)
-    diffs = generate_diffs(m1, m2)
+    pairs = _pair_records(m1, m2)
     results: list[dict] = []
-    for (key, field), diff in diffs.items():
-        if diff.status != "diff":
-            continue
-        conflict = is_conflict(str(diff.value1), str(diff.value2), field)
-        results.append(
-            {
-                "key": key,
-                "field": field,
-                "v1": diff.value1,
-                "v2": diff.value2,
-                "conflict": conflict,
-            }
-        )
+    for rec1, rec2 in pairs:
+        key = rec1.get("doi") or rec2.get("doi") or rec1.get("title")
+        fields = sorted(set(rec1) | set(rec2))
+        for field in fields:
+            v1 = rec1.get(field)
+            v2 = rec2.get(field)
+            if v1 == v2:
+                continue
+            conflict = is_conflict(str(v1), str(v2), field)
+            results.append(
+                {
+                    "key": key,
+                    "field": field,
+                    "v1": v1,
+                    "v2": v2,
+                    "conflict": conflict,
+                }
+            )
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_bytes(orjson.dumps(results, option=orjson.OPT_INDENT_2))
     logger.info(

--- a/agent3/json_matcher.py
+++ b/agent3/json_matcher.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from rapidfuzz.fuzz import token_set_ratio
+
+
+_punct_re = re.compile(r"[^\w\s]")
+
+
+def _normalize(title: str) -> str:
+    text = unicodedata.normalize("NFD", title)
+    text = text.encode("ascii", "ignore").decode("ascii")
+    text = text.lower()
+    text = _punct_re.sub(" ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def fuzzy_match_titles(title_a: str, title_b: str, threshold: int = 90) -> int | None:
+    """Return the similarity score if ``title_a`` and ``title_b`` match."""
+    score = token_set_ratio(_normalize(title_a), _normalize(title_b))
+    return score if score >= threshold else None

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ faiss-cpu
 scikit-learn
 numpy
 psutil
+rapidfuzz


### PR DESCRIPTION
## Summary
- add `json_matcher.fuzzy_match_titles` helper using RapidFuzz
- refactor `compare_masters.py` to pair records by title similarity
- adjust tests for new matching rules
- update requirements and README

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fc683b5e0832cb0d06ddd3478eb15