### PR TITLE
Add unmatched-paper reporting in master comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Records are now paired on title similarity (`token_set_ratio` ≥ 90 %). DOI is 
    ```
 
    The command writes `data/validation/comparison_<timestamp>.json` listing all
-   field differences.
+   field differences. The script also logs how many papers were paired and
+   prints any titles that could not be matched.
 
 2. **Resolve conflicts**
 

--- a/tests/agent3/test_compare_masters.py
+++ b/tests/agent3/test_compare_masters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import types
 from pathlib import Path
+import logging
 import orjson
 
 # Stub out openai_validator before importing module
@@ -101,3 +102,17 @@ def test_doi_tie_breaker(tmp_path: Path) -> None:
         "v2": "Alpha Beta Updated",
         "conflict": True,
     } in results
+
+
+def test_logs_unmatched_titles(tmp_path: Path, caplog) -> None:
+    m1 = tmp_path / "m1.json"
+    m2 = tmp_path / "m2.json"
+    create_master(m1, [{"title": "First"}])
+    create_master(m2, [{"title": "Second"}])
+
+    out = tmp_path / "out.json"
+    with caplog.at_level(logging.INFO):
+        compare_masters.compare(m1, m2, out)
+
+    assert "Matched 0 papers" in caplog.text
+    assert "No match for: First; Second" in caplog.text


### PR DESCRIPTION
## Summary
- report how many papers were paired when comparing masters
- print a summary of unmatched titles
- document the new behaviour in the README
- test logging of unmatched titles

## Testing
- `ruff check agent3/compare_masters.py tests/agent3/test_compare_masters.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fe492f228832c8211294a356b0a25