### PR TITLE
Add cleaned master generation with drug name

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Below is a brief description of the main scripts and where their outputs are wri
 - `cli/resolve_conflicts.py` resolves conflicting fields recorded in a comparison JSON.
   Use `--auto` to choose version 1 or 2 automatically.
 - `agent3/write_validated_master.py` merges two master files using a resolution
-  JSON and writes a validated master plus a metadata summary.
+  JSON and writes a cleaned master plus a metadata summary.
 - `run_validation.py` runs the full master validation workflow in one step.
 
 ## Master-to-Master Validation (Agent 3)
@@ -103,10 +103,11 @@ Records are now paired on title similarity (`token_set_ratio` ≥ 90 %). DOI is 
    python agent3/write_validated_master.py \
        path/to/master_v1.json \
        path/to/master_v2.json \
-       data/validation/resolution_<timestamp>.json
+       data/validation/resolution_<timestamp>.json \
+       --drug <drug-name>
    ```
 
-   The script outputs `master_validated_<timestamp>.json` and
+   The script outputs `master_<drug-name>_cleaned_<timestamp>.json` and
    `master_validated_meta_<timestamp>.json` in `data/validation/`.
 
 You can also run the entire process in one command:
@@ -273,7 +274,7 @@ contacting the API.
 - Aggregated metadata in `data/master.json`.
 - Generated narrative reviews in `outputs/`.
 - Retrieved snippets saved to `snippets.json` before the narrative step.
-- Validation comparisons, resolutions and validated masters in `data/validation/`.
+- Validation comparisons, resolutions and cleaned masters in `data/validation/`.
 - For instructions on processing a new drug, see `docs/HOW_TO_ADD_NEW_DRUG.md`.
 
 ## Cleaning Up Generated Data

--- a/agent3/write_validated_master.py
+++ b/agent3/write_validated_master.py
@@ -12,7 +12,12 @@ OUT_DIR = Path("data/validation")
 
 
 def merge_masters(
-    m1_path: Path, m2_path: Path, res_path: Path, out_dir: Path
+    m1_path: Path,
+    m2_path: Path,
+    res_path: Path,
+    out_dir: Path,
+    *,
+    drug: str | None = None,
 ) -> tuple[Path, Path]:
     m1 = load_master(m1_path)
     m2 = load_master(m2_path)
@@ -41,7 +46,11 @@ def merge_masters(
 
     timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
     out_dir.mkdir(parents=True, exist_ok=True)
-    master_path = out_dir / f"master_validated_{timestamp}.json"
+    if drug:
+        master_name = f"master_{drug}_cleaned_{timestamp}.json"
+    else:
+        master_name = f"master_validated_{timestamp}.json"
+    master_path = out_dir / master_name
     meta_path = out_dir / f"master_validated_meta_{timestamp}.json"
     master_path.write_bytes(orjson.dumps(records, option=orjson.OPT_INDENT_2))
 
@@ -66,6 +75,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("master_v2", help="Path to master_v2.json")
     parser.add_argument("resolution", help="Path to resolution JSON")
     parser.add_argument("--out_dir", default=str(OUT_DIR), help="Output directory")
+    parser.add_argument("--drug", help="Drug name used for output file naming")
     args = parser.parse_args(argv)
 
     merge_masters(
@@ -73,6 +83,7 @@ def main(argv: list[str] | None = None) -> int:
         Path(args.master_v2),
         Path(args.resolution),
         Path(args.out_dir),
+        drug=args.drug,
     )
     return 0
 

--- a/tests/agent3/test_write_validated_master.py
+++ b/tests/agent3/test_write_validated_master.py
@@ -48,11 +48,13 @@ def test_cli(tmp_path: Path, monkeypatch) -> None:
             str(res_path),
             "--out_dir",
             str(out_dir),
+            "--drug",
+            "DrugX",
         ]
     )
     assert code == 0
 
-    master_path = out_dir / "master_validated_20240102_030405.json"
+    master_path = out_dir / "master_DrugX_cleaned_20240102_030405.json"
     meta_path = out_dir / "master_validated_meta_20240102_030405.json"
 
     data = orjson.loads(master_path.read_bytes())

--- a/tests/integration/test_end_to_end_conflict_resolution.py
+++ b/tests/integration/test_end_to_end_conflict_resolution.py
@@ -50,10 +50,12 @@ def test_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
             str(res_path),
             "--out_dir",
             str(out_dir),
+            "--drug",
+            "DrugY",
         ]
     )
     assert write_code == 0
-    master_path = out_dir / "master_validated_20240102_030405.json"
+    master_path = out_dir / "master_DrugY_cleaned_20240102_030405.json"
     meta_path = out_dir / "master_validated_meta_20240102_030405.json"
     data = orjson.loads(master_path.read_bytes())
     assert data == [


### PR DESCRIPTION
## Summary
- add `--drug` option to `write_validated_master.py`
- name merged master files `master_<drug>_cleaned_<timestamp>.json`
- update README instructions
- adjust tests for new naming scheme

## Testing
- `ruff format . --quiet`
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68725ad570e4832c90001b251eccd466